### PR TITLE
Pick a Ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: ruby
+rvm:
+  - "2.0.0"


### PR DESCRIPTION
Travis defaults to 1.9, which is probably getting diminishing attention.  Anyway we want this pinned down so that we get reproducible results.

Just for fun, I added it array-style, to slightly facilitate supporting multiple versions someday.
