### PR TITLE
HPT-99: Using Jettywrapper startup_wait parameter to allow startup time

### DIFF
--- a/config/jetty.yml
+++ b/config/jetty.yml
@@ -6,7 +6,7 @@ default:
     - "-Xmx256m"
 test:
   jetty_port: 8983
-  startup_wait: 90
+  startup_wait: 120
   java_opts:
     - "-XX:MaxPermSize=128m" 
     - "-Xmx256m"

--- a/config/jetty.yml
+++ b/config/jetty.yml
@@ -1,5 +1,13 @@
 default:
   jetty_port: 8983
+  startup_wait: 30
   java_opts:
     - "-XX:MaxPermSize=128m" 
     - "-Xmx256m"
+test:
+  jetty_port: 8983
+  startup_wait: 90
+  java_opts:
+    - "-XX:MaxPermSize=128m" 
+    - "-Xmx256m"
+

--- a/lib/tasks/pmp-tasks.rake
+++ b/lib/tasks/pmp-tasks.rake
@@ -21,11 +21,8 @@ desc 'Run specs on travis'
 task :ci do
   ENV['RAILS_ENV'] = 'test'
   ENV['TRAVIS'] = '1'
-  #Jettywrapper.unzip
   jetty_params = Jettywrapper.load_config
   error = Jettywrapper.wrap(jetty_params) do
-    puts "Sleeping for 60 seconds to give Jetty time to start"
-    sleep(60)  
     Rake::Task['spec'].invoke
   end
   raise "test failures: #{error}" if error


### PR DESCRIPTION
This pull request changes the startup_wait time in the Jetty configuration in: config/jetty.yml

And removes the sleep from the 'ci' task in lib/tasks/pmp-tasks.rake

By doing so, the Jettywrapper startup will only wait as long as it takes up to the specified value, vs. a sleep command which will annoyingly wait no matter what. If set at 90 and the port becomes available in 30, then the command will return. For default, the new value is 30, for test it is 120 because Travis seems to take even longer to deploy the container.
