### PR TITLE
[HPT-133] Customize search index.

### DIFF
--- a/app/views/catalog/_document_header.html.erb
+++ b/app/views/catalog/_document_header.html.erb
@@ -1,0 +1,15 @@
+      <% # header bar for doc items in index view -%>
+      <div class="documentHeader clearfix">
+        
+        <%- # main title container for doc partial view -%>
+         <h5 class="index_title">
+           <span class="index_number">
+             <% counter = document_counter_with_offset(document_counter) %>
+             <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
+           </span>
+         <%= link_to_document document, :label=>document_show_link_field(document), :counter => counter %>
+        </h5>
+
+        <% # bookmark functions for items/docs -%>
+        <%= render_index_doc_actions document, :wrapping_class => "documentFunctions span2" %>
+      </div>

--- a/app/views/catalog/_index_default.html.erb
+++ b/app/views/catalog/_index_default.html.erb
@@ -1,0 +1,11 @@
+<%# default partial to display solr document fields in catalog index view -%>
+<dl class="document-metadata dl-horizontal dl-invert">
+  
+  <% index_fields(document).each do |solr_fname, field| -%>
+    <% if should_render_index_field? document, field %>
+	    <dt class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_label document, :field => solr_fname %></dt>
+	    <dd class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_value document, :field => solr_fname %></dd>
+    <% end -%>
+  <% end -%>
+
+</dl>

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -36,6 +36,13 @@ require 'spec_helper'
         within('#documents'){expect(page).to have_content @test_paged.title}
       end
     end
+    context "search results" do
+      it "should have index numbers surrounded by span tag with an index_number class" do
+        visit root_path
+        click_button 'Search'
+        within('#documents'){expect(page).to have_css('span.index_numbers')}
+      end
+    end
     
     after(:all) do
       @test_paged.delete

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -40,7 +40,7 @@ require 'spec_helper'
       it "should have index numbers surrounded by span tag with an index_number class" do
         visit root_path
         click_button 'Search'
-        within('#documents'){expect(page).to have_css('span.index_numbers')}
+        within('#documents'){expect(page).to have_css('span.index_number')}
       end
     end
     


### PR DESCRIPTION
Two files were pulled out of blacklight and added to our app {app/views/catalog/*}. These files build the search results index page. The only customization made was to surround the number before each search result with a span tag having a css class assignment.
