### PR TITLE
HPT-28 Authentication with IU CAS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,9 @@ end
 gem "bootstrap-sass"
 gem "devise"
 gem "devise-guests", "~> 0.3"
+gem 'omniauth'
+gem 'omniauth-cas', :git => "https://github.com/cjcolvar/omniauth-cas.git"
+
 group :development, :test do
   gem "rspec-rails"
   gem "capybara"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/cjcolvar/omniauth-cas.git
+  revision: b6ba1d9208ce230d97cd74681fed87224f0501f8
+  specs:
+    omniauth-cas (0.0.7)
+      addressable (~> 2.2)
+      nokogiri (~> 1.5)
+      omniauth (~> 1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -37,6 +46,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
+    addressable (2.3.6)
     arel (5.0.1.20140414130214)
     bcrypt (3.1.7)
     blacklight (4.5.0)
@@ -92,6 +102,7 @@ GEM
       railties (>= 3.0.0)
     fastercsv (1.5.5)
     ffi (1.9.3)
+    hashie (2.1.1)
     hike (1.2.3)
     hooks (0.3.6)
       uber (~> 0.0.4)
@@ -167,6 +178,9 @@ GEM
       mediashelf-loggable
       nokogiri (>= 1.4.2)
       solrizer (~> 3.1.0)
+    omniauth (1.2.1)
+      hashie (>= 1.2, < 3)
+      rack (~> 1.0)
     orm_adapter (0.5.0)
     polyglot (0.3.4)
     rack (1.5.2)
@@ -286,6 +300,8 @@ DEPENDENCIES
   jbuilder (~> 1.2)
   jettywrapper
   jquery-rails
+  omniauth
+  omniauth-cas!
   rails (~> 4.1)
   rspec-rails
   sass-rails (~> 4.0.0)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,15 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def cas
+    # You need to implement the method below in your model (e.g. app/models/user.rb)
+    @user = User.find_for_iu_cas(request.env["omniauth.auth"])
+
+    if @user.persisted?
+      sign_in_and_redirect @user, :event => :authentication #this will throw if @user is not activated
+      set_flash_message(:notice, :success, :kind => "IU CAS") if is_navigational_format?
+    else
+      session["devise.cas_data"] = request.env["omniauth.auth"]
+      redirect_to new_user_registration_url
+    end
+  end
+
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,8 +8,8 @@ class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :token_authenticatable, :confirmable,
   # :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+  devise :database_authenticatable, :registerable, :omniauthable, 
+         :recoverable, :rememberable, :trackable, :validatable, :omniauth_providers => [:cas]
 
             # Method added by Blacklight; Blacklight uses #to_s on your
             # user class to get a user-displayable login/identifier for

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,4 +17,12 @@ class User < ActiveRecord::Base
             def to_s
               email
             end
-          end
+  def self.find_for_iu_cas(auth)
+    where(auth.slice(:provider, :uid)).first_or_create! do |user|
+      user.provider = auth.provider
+      user.uid = auth.uid
+      user.email = [auth.uid,'@indiana.edu'].join
+      user.password = Devise.friendly_token[0,20]
+    end
+  end
+end

--- a/app/views/devise/shared/_links.erb
+++ b/app/views/devise/shared/_links.erb
@@ -1,0 +1,25 @@
+<%- if devise_mapping.omniauthable? %>
+  <%= link_to "Sign in with IU CAS", omniauth_authorize_path(resource_name, :cas) %><br />
+<% end -%>
+
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Sign in", new_session_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+<% end -%>
+
+

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -220,6 +220,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', :scope => 'user,public_repo'
+  config.omniauth :cas, :host => 'cas.iu.edu', :login_url => '/cas/login', :service_validate_url => '/cas/validate', :logout_url => '/cas/logout', :ssl => true
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,8 @@ PagedMedia::Application.routes.draw do
   root :to => "catalog#index"
   Blacklight.add_routes(self)
   HydraHead.add_routes(self)
-  devise_for :users
+  #devise_for :users
+  devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/db/migrate/20140529170634_add_columns_to_users.rb
+++ b/db/migrate/20140529170634_add_columns_to_users.rb
@@ -1,0 +1,6 @@
+class AddColumnsToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140324205349) do
+ActiveRecord::Schema.define(version: 20140529170634) do
 
   create_table "bookmarks", force: true do |t|
     t.integer  "user_id",     null: false
@@ -46,6 +46,8 @@ ActiveRecord::Schema.define(version: 20140324205349) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "guest",                  default: false
+    t.string   "provider"
+    t.string   "uid"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true

--- a/spec/features/iu_cas_spec.rb
+++ b/spec/features/iu_cas_spec.rb
@@ -5,16 +5,8 @@ describe "Access to signin page" do
     page.should have_content("Sign in with IU CAS")
     set_omniauth()
     click_link "Sign in with IU CAS"
-    page.should have_content("mock user")  # user name
-    page.should have_content("Sign out")
-  end
-
-  it "can handle authentication error" do
-    OmniAuth.config.mock_auth[:iu_cas] = :invalid_credentials
-    visit '/users/sign_in'
-    page.should have_content("Sign in with IU CAS")
-    click_link "Sign in with IU CAS"
-    page.should have_content('Authentication failed.')
+    page.should have_content("1234@indiana.edu")  # user name
+    page.should have_content("Log Out")
   end
 
 end

--- a/spec/features/iu_cas_spec.rb
+++ b/spec/features/iu_cas_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+describe "Access to signin page" do
+  it "can sign in user with IU CAS" do
+    visit '/users/sign_in'
+    page.should have_content("Sign in with IU CAS")
+    set_omniauth()
+    click_link "Sign in with IU CAS"
+    page.should have_content("mock user")  # user name
+    page.should have_content("Sign out")
+  end
+
+  it "can handle authentication error" do
+    OmniAuth.config.mock_auth[:iu_cas] = :invalid_credentials
+    visit '/users/sign_in'
+    page.should have_content("Sign in with IU CAS")
+    click_link "Sign in with IU CAS"
+    page.should have_content('Authentication failed.')
+  end
+
+end

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,0 +1,40 @@
+
+def set_omniauth(opts = {})
+  default = {:provider => :iu_cas,
+             :uuid     => "1234",
+             :iu_cas => {
+                            :email => "mockuser@nowhere.edu",
+                            :first_name => "mock",
+                            :last_name => "user"
+                          }
+            }
+
+  credentials = default.merge(opts)
+  provider = credentials[:provider]
+  user_hash = credentials[provider]
+
+  OmniAuth.config.test_mode = true
+
+  OmniAuth.config.mock_auth[provider] = {
+    'uid' => credentials[:uuid],
+    "extra" => {
+    "user_hash" => {
+      "email" => user_hash[:email],
+      "first_name" => user_hash[:first_name],
+      "last_name" => user_hash[:last_name],
+      }
+    }
+  }
+end
+
+def set_invalid_omniauth(opts = {})
+
+  credentials = { :provider => :iu_cas,
+                  :invalid  => :invalid_crendentials
+                 }.merge(opts)
+
+  OmniAuth.config.test_mode = true
+  OmniAuth.config.mock_auth[credentials[:provider]] = credentials[:invalid]
+
+end
+


### PR DESCRIPTION
This pull request enables Omniauth and the omniauth-cas strategy
to allow login via IU CAS. It includes the following changes:

Gemfile:
Adds omniauth and omniauth-cas

app/controllers/users/omniauth_callbacks_controller.rb:
Handles the callback from omniauth to create a Devise user session and to persist
in DB on first login.

app/models/user.rb:
Makes the Devise user omniauthable

app/views/devise/shared/_links.erb:
Overrides the default Devise links partial so we have control over login links and labels

config/initializers/devise.rb:
Configures the :cas omniauth strategy using Devise config blocks

config/routes.rb:
Adds routes for the omniauth callback

Database schema change adds columns that require doing rake db:migrate

spec/features/iu_cas_spec.rb:
The Rspec test that uses ominiauth mocking capabilities to setup and test the callbacks

spec/support/omniauth.rb
Adds custom supporting methods specific to omniauth that can be used in specs
