### PR TITLE
[HPT-160] Replace physical page number with previous-, next-page references

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -52,9 +52,6 @@ class PagesController < ApplicationController
   # PATCH/PUT /pages/1.json
   def update
     respond_to do |format|
-      @page.image_file = params[:image_file] if params.has_key?(:image_file)
-      @page.ocr_file = params[:ocr_file] if params.has_key?(:ocr_file)
-      @page.xml_file = params[:xml_file] if params.has_key?(:xml_file)
       if @page.update(page_params)
         format.html do
           if (:paged == session.delete(:came_from))
@@ -94,8 +91,7 @@ class PagesController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def page_params
-      params.require(:page)
-      params.permit(:logical_number, :physical_number,
+      params.require(:page).permit(:logical_number, :prev_page, :next_page,
         :image_file, :paged_id, :ocr_file, :xml_file)
     end
 end

--- a/app/models/datastreams/page_metadata.rb
+++ b/app/models/datastreams/page_metadata.rb
@@ -5,9 +5,9 @@ class PageMetadata < ActiveFedora::OmDatastream
   set_terminology do |t|
     t.root(path: 'fields')
     t.logical_number index_as: :stored_searchable
-    t.physical_number index_as: :stored_searchable, type: :integer
+    t.prev_page index_as: :stored_searchable
+    t.next_page index_as: :stored_searchable
     t.text index_as: :stored_searchable
-
   end
 
   def self.xml_template

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -15,7 +15,8 @@ class Page < ActiveFedora::Base
   has_file_datastream 'pageXML'
 
   has_attributes :logical_number, datastream: 'descMetadata',  multiple: false
-  has_attributes :physical_number, datastream: 'descMetadata',  multiple: false
+  has_attributes :prev_page, datastream: 'descMetadata', multiple: false
+  has_attributes :next_page, datastream: 'descMetadata', multiple: false
   has_attributes :text,  datastream: 'descMetadata', multiple: false
 
   # Setter for the image

--- a/app/views/pages/_add_page_form.html.erb
+++ b/app/views/pages/_add_page_form.html.erb
@@ -5,8 +5,12 @@
     <%= f.text_field :logical_number %>
   </div>
   <div class="field">
-    <%= f.label :physical_number %><br>
-    <%= f.text_field :physical_number %>
+    <%= f.label 'Previous page' %><br>
+    <%= f.text_field :prev_page %>
+  </div>
+  <div class="field">
+    <%= f.label 'Next page' %><br>
+    <%= f.text_field :next_page %>
   </div>
   <div class='field'>
     <%= f.label 'Page image file:' %><br />

--- a/app/views/pages/_form.html.erb
+++ b/app/views/pages/_form.html.erb
@@ -16,8 +16,12 @@
     <%= f.text_field :logical_number %>
   </div>
   <div class="field">
-    <%= f.label :physical_number %><br>
-    <%= f.text_field :physical_number %>
+    <%= f.label 'Previous page:' %><br>
+    <%= f.text_field :prev_page %>
+  </div>
+  <div class="field">
+    <%= f.label 'Next page:' %><br>
+    <%= f.text_field :next_page %>
   </div>
   <div class='field'>
     <% if !@page.new? %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -4,7 +4,8 @@
   <thead>
     <tr>
       <th>Logical number</th>
-      <th>Physical number</th>
+      <th>Previous page</th>
+      <th>Next page</th>
       <th></th>
       <th></th>
       <th></th>
@@ -15,7 +16,8 @@
     <% @pages.each do |page| %>
       <tr>
         <td><%= page.logical_number %></td>
-        <td><%= page.physical_number %></td>
+        <td><%= page.prev_page %></td>
+        <td><%= page.next_page %>
         <td><%= link_to 'Show', page %></td>
         <td><%= link_to 'Edit', edit_page_path(page) %></td>
         <td><%= link_to 'Destroy', page, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/pages/show.html.erb
+++ b/app/views/pages/show.html.erb
@@ -12,8 +12,13 @@
 </p>
 
 <p>
-  <strong>Physical number:</strong>
-  <%= @page.physical_number %>
+  <strong>Previous page:</strong>
+  <%= @page.prev_page %>
+</p>
+
+<p>
+  <strong>Next page:</strong>
+  <%= @page.next_page %>
 </p>
 
 <% if @page.ocr_file %>

--- a/spec/controllers/page_controller_spec.rb
+++ b/spec/controllers/page_controller_spec.rb
@@ -23,6 +23,28 @@ describe PagesController do
   end
 
   describe 'PUT update' do
+    it 'stores a previous-page link' do
+      apage = mock_model(Page, :prev_page= => nil, update: nil)
+      expect(Page).to receive(:find).and_return(apage)
+      expect(apage).to receive(:update).with('prev_page' => 'page:3')
+      put :update, {
+        page: {prev_page: 'page:3'},
+        id: 'page:4'
+      }
+      assert_response :success
+    end
+
+    it 'stores a next-page link' do
+      apage = mock_model(Page, :next_page= => nil, update: nil)
+      expect(Page).to receive(:find).and_return(apage)
+      expect(apage).to receive(:update).with('next_page' => 'page:5')
+      put :update, {
+        page: {next_page: 'page:5'},
+        id: 'page:4'
+      }
+      assert_response :success
+    end
+
     it 'stores a new image datastream'
 
     it 'stores a new OCR datastream'
@@ -38,9 +60,8 @@ describe PagesController do
       expect(Page).to receive(:find).and_return(apage)
       expect(apage).to receive(:update).with('xml_file' => xml_upload)
       put :update, {
-        page: apage,
-        id: '1',
-        xml_file: xml_upload
+        page: {xml_file: xml_upload},
+        id: '1'
       }
       assert_response :success
     end

--- a/spec/models/page_spec.rb
+++ b/spec/models/page_spec.rb
@@ -22,7 +22,8 @@ describe Page do
   it { should respond_to(:xml_file) }
 
   it { should respond_to(:logical_number) }
-  it { should respond_to(:physical_number) }
   it { should respond_to(:text) }
+  it { should respond_to(:prev_page) }
+  it { should respond_to(:next_page) }
 
 end


### PR DESCRIPTION
Also undo a previous commit that split the composition of params.require from params.permit in Page.  That previous commit papered over the real problem, which was that the tests themselves were wrong, and broke Page.update and Page.save.
