### PR TITLE
[HPT-166] Handle empty xml file

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -158,7 +158,13 @@ class Page < ActiveFedora::Base
       end
     end
 
-    return false if ! super()
+    begin
+      return false if ! super()
+    rescue RestClient::BadRequest => e
+      errors[:base] << e.message
+      errors[:base] << 'Check for a damaged or invalid file'
+      return false
+    end
 
     if (!unset(prev_page))
       prev_sib = Page.find(prev_page)


### PR DESCRIPTION
https://bugs.dlib.indiana.edu/browse/HPT-166

It seems the best we can do is handle the BadRequest raised by the 400
response from Fedora, display it and make suggestions.  I couldn't
find a way to get specifics from the stack.
