### PR TITLE
HPT-256: Solrizing ordered page lists to improve performance of the BookReader

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -36,6 +36,8 @@ class PagesController < ApplicationController
       @page.paged_id = params[:paged_id] if params.has_key?(:paged_id)
       if @page.save
         if @page.paged_id
+          paged = Paged.find(@page.paged_id)
+          paged.update_index 
           format.html { redirect_to "/pageds/" + @page.paged_id, notice: 'Page was successfully created.'}
         else
           format.html { redirect_to @page, notice: 'Page was successfully created.' }

--- a/app/models/paged.rb
+++ b/app/models/paged.rb
@@ -96,4 +96,21 @@ class Paged < ActiveFedora::Base
     return [ordered_pages, error]
   end
 
+  def page_list
+    pages = []
+    fedora_url = ActiveFedora.fedora_config.credentials[:url] + '/'
+    self.order_pages[0].each_with_index do |page, index|
+      pages.push({:id => page.pid, :index => index.to_s, :ds_url => fedora_url + page.image_datastream.url})
+    end
+    pages
+  end
+
+  def to_solr(solr_doc={}, opts={})
+    pages = self.page_list
+    super(solr_doc, opts)
+    solr_doc[Solrizer.solr_name('pages', 'ss')] = pages.to_json # single value field as json
+    solr_doc[Solrizer.solr_name('pages', 'ssm')] = pages # multivalue field as ruby hash
+    return solr_doc
+  end
+
 end

--- a/app/script/load_score.rb
+++ b/app/script/load_score.rb
@@ -4,6 +4,7 @@ describe 'Loading objects' do
 
   before(:all) do
     @test_paged = create(:paged, :score, :with_score_pages)
+    @test_paged.update_index
   end
 
   context 'Loading an example score' do

--- a/app/views/pageds/index.html.erb
+++ b/app/views/pageds/index.html.erb
@@ -20,7 +20,7 @@
         <td><%= paged.creator %></td>
         <td><%= paged.publisher %></td>
         <td><%= paged.issued %></td>
-        <td><%= link_to 'View in BookReader', bookreader_paged_path(paged) + '#page/1/mode/2up' %></td>
+        <td><%= link_to 'View in BookReader', bookreader_paged_path(paged) + '#page/1/mode/2up', target: "_blank" %></td>
         <td><%= link_to 'Show', paged %></td>
         <td><%= link_to 'Edit', edit_paged_path(paged) %></td>
         <td><%= link_to 'Destroy', paged, method: :delete, data: { confirm: 'Are you sure?' } %></td>

--- a/app/views/pageds/show.html.erb
+++ b/app/views/pageds/show.html.erb
@@ -36,7 +36,7 @@
   <% end %>
 </p>
 
-<%= link_to 'View in BookReader', bookreader_paged_path(@paged) + '#page/1/mode/2up'%> |
+<%= link_to 'View in BookReader', bookreader_paged_path(@paged) + '#page/1/mode/2up', target: "_blank"%> |
 <%= link_to 'Edit', edit_paged_path(@paged) %> |
 <%= link_to 'Back', pageds_path %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ PagedMedia::Application.routes.draw do
   resources :pageds do
     patch :reorder, on: :member
     get :page, on: :member
-#    get '/page/:index' => 'pageds#page'
+    get :pages, on: :member
     get :bookreader, on: :member
   end
 

--- a/spec/controllers/paged_controller_spec.rb
+++ b/spec/controllers/paged_controller_spec.rb
@@ -5,11 +5,12 @@ describe PagedsController do
 
   before(:all) do
     @test_paged = create(:paged, :with_pages)
+    @test_paged.update_index
   end
 
   context '#page' do
     it 'should return pid and image ds uri given an index integer' do
-      get :page, id: @test_paged.id, index: 1
+      get :pages, id: @test_paged.id, index: 1
       parsed = JSON.parse response.body
       expect(parsed['id']).to eq @test_paged.pages[1].pid
       expect(parsed['index']).to eq 1.to_s

--- a/vendor/assets/javascripts/BookReader.js
+++ b/vendor/assets/javascripts/BookReader.js
@@ -34,6 +34,8 @@ This file is part of BookReader.
 //  - getSpreadIndices()
 // You must also add a numLeafs property before calling init().
 
+var imagesBaseURL = '/assets/';
+
 function BookReader() {
 
     // Mode constants
@@ -86,7 +88,7 @@ function BookReader() {
     // custom implementations.
     // $$$ This is the same directory as the images referenced by relative
     //     path in the CSS.  Would be better to automagically find that path.
-    this.imagesBaseURL = '/bookreader/images/';
+    this.imagesBaseURL = '/assets/';
     
     
     // Zoom levels
@@ -697,7 +699,7 @@ BookReader.prototype.drawLeafsThumbnail = function( seekIndex ) {
                 img = document.createElement("img");
                 var thumbReduce = Math.floor(this.getPageWidth(leaf) / this.thumbWidth);
                 
-                $(img).attr('src', this.imagesBaseURL + 'transparent.png')
+                $(img).attr('src', imagesBaseURL + 'transparent.png')
                     .css({'width': leafWidth+'px', 'height': leafHeight+'px' })
                     .addClass('BRlazyload')
                     // Store the URL of the image that will replace this one
@@ -4595,7 +4597,7 @@ BookReader.prototype._getPageHeight= function(index) {
 // Returns the page URI or transparent image if out of range
 BookReader.prototype._getPageURI = function(index, reduce, rotate) {
     if (index < 0 || index >= this.numLeafs) { // Synthesize page
-        return this.imagesBaseURL + "transparent.png";
+        return imagesBaseURL + "transparent.png";
     }
     
     if ('undefined' == typeof(reduce)) {

--- a/vendor/assets/javascripts/BookReaderJSSimple.js.erb
+++ b/vendor/assets/javascripts/BookReaderJSSimple.js.erb
@@ -6,6 +6,17 @@
 // Create the BookReader object
 br = new BookReader();
 
+// Get list of pages for a given paged item, returned as a JSON array of pages.
+var paged_pages_url = '/pageds/' + paged_id + '/pages';
+var paged_pages = $.ajax({
+    url: paged_pages_url,
+    type: 'get',
+    dataType: 'json',
+    async:false,
+    }).responseText;
+// Parse and store as global so that getPageURI can leaf through it
+var pages_json = JSON && JSON.parse(paged_pages) || $.parseJSON(paged_pages);
+
 // Return the width of a given page.  Here we assume all images are 800 pixels wide
 br.getPageWidth = function(index) {
     return 800;
@@ -23,21 +34,7 @@ br.getPageURI = function(index, reduce, rotate) {
     // could e.g. look at reduce and load images from a different directory
     // or pass the information to an image server
 
-    var json_string = br.getPagedJSON(index, reduce, rotate)
-    var json_object = JSON && JSON.parse(json_string) || $.parseJSON(json_string);
-    return json_object.ds_url;
-}
-
-br.getPagedJSON = function(index, reduce, rotate) {
-    var request_url = '/pageds/' + paged_id + '/page?index=' + index;
-    var json_string = $.ajax({
-        url: request_url,
-        type: 'get',
-        dataType: 'json',
-        async:false,
-        }).responseText;
-
-    return json_string;
+    return pages_json[index].ds_url;
 }
 
 // Return which side, left or right, that a given page should be displayed on


### PR DESCRIPTION
This commit touches a number of files and adds/changes the following:

Added paged model method to override to_solr so a list of child pages can be solrized
Added 'pages' action to paged controller to access Solr for ordered pages instead of using order_pages.
Made the pages action dual purpose to return a list, or single page if sent an index parameter.
Added update_index action to the pages controller so that pages are solrized on 'reorder' and 'create'.
Changed the BookReader JS to cache a list of page URIs upfront instead of making a call for each page.
Fixed a problem with the BookReader where some icon paths didn't have the correct asset base.
Changed bookreader links to open the 2up view in a new tab.
Adjusted tests to point to 'pages' action; added indexing step so that page additions are properly solrized.
