### PR TITLE
[hpt-249] Add place of publication to paged object metadata.

### DIFF
--- a/app/controllers/pageds_controller.rb
+++ b/app/controllers/pageds_controller.rb
@@ -130,7 +130,7 @@ class PagedsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def paged_params
-      params.require(:paged).permit(:type, :title, :creator, :publisher, :issued, :xml_file)
+      params.require(:paged).permit(:type, :title, :creator, :publisher, :publisher_place, :issued, :xml_file)
     end
 
     def reorder_params

--- a/app/models/datastreams/paged_metadata_oai_dc.rb
+++ b/app/models/datastreams/paged_metadata_oai_dc.rb
@@ -12,6 +12,7 @@ class PagedMetadataOaiDc < ActiveFedora::OmDatastream
     t.title(namespace_prefix: 'dc', index_as: :stored_searchable)
     t.creator(namespace_prefix: 'dc', index_as: :stored_searchable)
     t.publisher(namespace_prefix: 'dc', index_as: :stored_searchable)
+    t.publisher_place(namespace_prefix: 'dc', index_as: :stored_searchable)
     t.issued(namespace_prefix: 'dc', index_as: :stored_searchable, type: :date)
   end
 

--- a/app/models/paged.rb
+++ b/app/models/paged.rb
@@ -15,8 +15,8 @@ class Paged < ActiveFedora::Base
   has_attributes :title, datastream: 'descMetadata', multiple: false  # TODO update DC.title as well?
   has_attributes :creator, datastream: 'descMetadata', multiple: false
   has_attributes :publisher, datastream: 'descMetadata', multiple: false
+  has_attributes :publisher_place, datastream: 'descMetadata', multiple: false
   has_attributes :issued, datastream: 'descMetadata', multiple: false
-  # TODO add place of publication
   has_attributes :type, datastream: 'descMetadata', multiple: false
 
 

--- a/app/views/pageds/_form.html.erb
+++ b/app/views/pageds/_form.html.erb
@@ -27,6 +27,10 @@
     <%= f.label :publisher %><br>
     <%= f.text_field :publisher %>
   </div>
+    <div class="field">
+    <%= f.label :publisher_place %><br>
+    <%= f.text_field :publisher_place %>
+  </div>
   <div class="field">
     <%= f.label "Date of Publication" %><br>
     <%= f.date_field :issued %>

--- a/app/views/pageds/index.html.erb
+++ b/app/views/pageds/index.html.erb
@@ -7,6 +7,7 @@
       <th>Title</th>
       <th>Creator</th>
       <th>Publisher</th>
+      <th>Place of Publication</th>
       <th>Date of Publication</th>
       <th colspan="4">Actions</th>
     </tr>
@@ -19,6 +20,7 @@
         <td><%= paged.title %></td>
         <td><%= paged.creator %></td>
         <td><%= paged.publisher %></td>
+        <td><%= paged.publisher_place %></td>
         <td><%= paged.issued %></td>
         <td><%= link_to 'View in BookReader', bookreader_paged_path(paged) + '#page/1/mode/2up' %></td>
         <td><%= link_to 'Show', paged %></td>

--- a/app/views/pageds/show.html.erb
+++ b/app/views/pageds/show.html.erb
@@ -21,6 +21,11 @@
 </p>
 
 <p>
+  <strong>Place of Publication:</strong>
+  <%= @paged.publisher_place %>
+</p>
+
+<p>
   <strong>Date of Publication:</strong>
   <%= @paged.issued %>
 </p>
@@ -36,9 +41,15 @@
   <% end %>
 </p>
 
-<%= link_to 'View in BookReader', bookreader_paged_path(@paged) + '#page/1/mode/2up'%> |
-<%= link_to 'Edit', edit_paged_path(@paged) %> |
-<%= link_to 'Back', pageds_path %>
+<div style="display:inline-block;">
+  <%= button_to 'View in BookReader', bookreader_paged_path(@paged) + '#page/1/mode/2up'%>
+</div>
+<div style="display:inline-block;">
+  <%= button_to 'Edit', edit_paged_path(@paged) %>
+</div>
+<div style="display:inline-block;">
+  <%= button_to 'Back', pageds_path %>
+</div>
 
 <hr/>
 

--- a/spec/factories/paged_factories.rb
+++ b/spec/factories/paged_factories.rb
@@ -12,6 +12,7 @@ FactoryGirl.define do
     title "Paged Object"
     creator "Factory Girl"
     publisher "Generic Publisher"
+    publisher_place "Metropolis"
     issued Time.now 
 
     #Create a test paged object

--- a/spec/models/paged_spec.rb
+++ b/spec/models/paged_spec.rb
@@ -23,6 +23,7 @@ describe Paged do
     expect(@paged.title).to be_present
     expect(@paged.creator).to be_present
     expect(@paged.publisher).to be_present
+    expect(@paged.publisher_place).to be_present
     expect(@paged.issued).to be_present
   end
   


### PR DESCRIPTION
Not sure if the label publication_place is right here. Our metadata specialist said she once used dc.publication.place, but that it is not found in the scheme these days. 
