### PR TITLE
HPT-272 navigate within a Paged structure

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -71,13 +71,13 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('subject_geo', :facetable), :label => 'Region'
     config.add_facet_field solr_name('subject_era', :facetable), :label => 'Era'
     config.add_facet_field solr_name('type'), label: 'Media Type'
-    config.add_facet_field solr_name('treestruct', :facetable), label: 'Collections', partial: 'blacklight/hierarchy/facet_hierarchy'
+    config.add_facet_field solr_name('paged_struct', :facetable), label: 'Collections', partial: 'blacklight/hierarchy/facet_hierarchy'
     config.add_facet_field solr_name('page_struct', :facetable), label: 'Contents', partial: 'blacklight/hierarchy/facet_hierarchy'
 
     config.facet_display = {
       :hierarchy => {
       'tag' => [nil],
-      'treestruct' => [['sim'], "--"],
+      'paged_struct' => [['sim'], "--"],
       'page_struct' => [['sim'], "--"]
       }
     }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -92,7 +92,7 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field solr_name('title', :stored_searchable, type: :string), :label => 'Title:'
+#    config.add_index_field solr_name('title', :stored_searchable, type: :string), :label => 'Title:'
     config.add_index_field solr_name('title_vern', :stored_searchable, type: :string), :label => 'Title:'
     config.add_index_field solr_name('author', :stored_searchable, type: :string), :label => 'Author:'
     config.add_index_field solr_name('author_vern', :stored_searchable, type: :string), :label => 'Author:'

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -25,12 +25,12 @@ class CatalogController < ApplicationController
 
   # List of unwanted models
   def unwanted_models
-    return[Page]
+    return[]
   end
 
   configure_blacklight do |config|
     config.default_solr_params = {
-      :qf => 'title_tesim creator_tesim type_tesim',
+      :qf => 'title_tesim creator_tesim type_tesim text_tesim',
       :qt => 'search',
       :rows => 10
     }
@@ -72,11 +72,13 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name('subject_era', :facetable), :label => 'Era'
     config.add_facet_field solr_name('type'), label: 'Media Type'
     config.add_facet_field solr_name('treestruct', :facetable), label: 'Collections', partial: 'blacklight/hierarchy/facet_hierarchy'
+    config.add_facet_field solr_name('page_struct', :facetable), label: 'Contents', partial: 'blacklight/hierarchy/facet_hierarchy'
 
     config.facet_display = {
       :hierarchy => {
       'tag' => [nil],
-      'treestruct' => [['sim'], "--"]
+      'treestruct' => [['sim'], "--"],
+      'page_struct' => [['sim'], "--"]
       }
     }
 

--- a/app/models/datastreams/page_metadata.rb
+++ b/app/models/datastreams/page_metadata.rb
@@ -8,6 +8,7 @@ class PageMetadata < ActiveFedora::OmDatastream
     t.prev_page index_as: :stored_searchable
     t.next_page index_as: :stored_searchable
     t.text index_as: :stored_searchable
+    t.page_struct index_as: :facetable
   end
 
   def self.xml_template

--- a/app/models/datastreams/paged_metadata_oai_dc.rb
+++ b/app/models/datastreams/paged_metadata_oai_dc.rb
@@ -14,7 +14,7 @@ class PagedMetadataOaiDc < ActiveFedora::OmDatastream
     t.publisher(namespace_prefix: 'dc', index_as: :stored_searchable)
     t.publisher_place(namespace_prefix: 'dc', index_as: :stored_searchable)
     t.issued(namespace_prefix: 'dc', index_as: :stored_searchable, type: :date)
-    t.treestruct(namespace_prefix: 'dc', index_as: :facetable)
+    t.paged_struct(namespace_prefix: 'dc', index_as: :facetable)
   end
 
   def self.xml_template

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -18,6 +18,7 @@ class Page < ActiveFedora::Base
   has_attributes :prev_page, datastream: 'descMetadata', multiple: false
   has_attributes :next_page, datastream: 'descMetadata', multiple: false
   has_attributes :text,  datastream: 'descMetadata', multiple: false
+  has_attributes :page_struct, datastream: 'descMetadata', multiple: true
 
   validate :validate_has_required_siblings
 

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -209,4 +209,12 @@ class Page < ActiveFedora::Base
     super
   end
 
+  def to_solr(solr_doc={}, opts={})
+    super(solr_doc, opts)
+    if (!paged.nil?)
+      solr_doc[Solrizer.solr_name('item_id', 'si')] = paged.pid
+    end
+    return solr_doc
+  end
+
 end

--- a/app/models/paged.rb
+++ b/app/models/paged.rb
@@ -18,7 +18,7 @@ class Paged < ActiveFedora::Base
   has_attributes :publisher_place, datastream: 'descMetadata', multiple: false
   has_attributes :issued, datastream: 'descMetadata', multiple: false
   has_attributes :type, datastream: 'descMetadata', multiple: false
-  has_attributes :treestruct, datastream: 'descMetadata', multiple: true
+  has_attributes :paged_struct, datastream: 'descMetadata', multiple: true
 
   # Setter for the XML datastream
   def xml_file=(file)

--- a/app/models/paged.rb
+++ b/app/models/paged.rb
@@ -110,6 +110,7 @@ class Paged < ActiveFedora::Base
     super(solr_doc, opts)
     solr_doc[Solrizer.solr_name('pages', 'ss')] = pages.to_json # single value field as json
     solr_doc[Solrizer.solr_name('pages', 'ssm')] = pages # multivalue field as ruby hash
+    solr_doc[Solrizer.solr_name('item_id', 'si')] = self.pid
     return solr_doc
   end
 

--- a/app/views/catalog/_document_header.html.erb
+++ b/app/views/catalog/_document_header.html.erb
@@ -15,6 +15,14 @@
 		  <%= t 'pmp.document.untitled.title' %>
 		<% end %>
               </a>
+          <% elsif document.document_type == "Page" %>
+              <a href='pages/<%= document.id %>'>
+	        <% if document.has_key?('logical_number_tesim') %>
+		  <%= document['logical_number_tesim'][0] %>
+		<% else %>
+		  <%= t 'pmp.document.untitled.title' %>
+		<% end %>
+              </a>
           <% else %>
             <%= link_to_document document, :label=>document_show_link_field(document), :counter => counter %>
           <% end %>

--- a/spec/factories/paged_factories.rb
+++ b/spec/factories/paged_factories.rb
@@ -71,11 +71,11 @@ FactoryGirl.define do
         #   of pageds found in the manifest file
         page_data = file_content["pageds"][0]["pages"]
         pages = Array.new
-        pages[0] = create(:page, paged: paged, logical_number: page_data["descMetadata"]["logical_num"][0])
+        pages[0] = create(:page, paged: paged, logical_number: page_data["descMetadata"]["logical_num"][0], text: page_data["descMetadata"]["text"][0], page_struct: page_data["descMetadata"]["page_struct"][0])
         paged.reload
         i = 1
         while i < page_data["page count"] do
-          pages[i] = create(:page, paged: paged, logical_number: page_data["descMetadata"]["logical_num"][i], prev_page: pages[i - 1].pid)
+          pages[i] = create(:page, paged: paged, logical_number: page_data["descMetadata"]["logical_num"][i], prev_page: pages[i - 1].pid, text: page_data["descMetadata"]["text"][i], page_struct: page_data["descMetadata"]["page_struct"][i])
           paged.reload
           i += 1
         end

--- a/spec/factories/paged_factories.rb
+++ b/spec/factories/paged_factories.rb
@@ -117,7 +117,7 @@ FactoryGirl.define do
       type file_content["pageds"][0]["descMetadata"]["type"]
       publisher file_content["pageds"][0]["descMetadata"]["publisher"]
       publisher_place file_content["pageds"][0]["descMetadata"]["publisher_place"]
-      treestruct file_content["pageds"][0]["descMetadata"]["treestruct"]
+      paged_struct file_content["pageds"][0]["descMetadata"]["paged_struct"]
     end
 
   end

--- a/spec/fixtures/ingest/pmp/package1/manifest.yml
+++ b/spec/fixtures/ingest/pmp/package1/manifest.yml
@@ -16,14 +16,14 @@ pageds:
    content:
      pagedXML: score_xml.xml
    pages:
-     page count: 3
+     page count: 5
      descMetadata:
        logical_num:
-         - Score Page 1
-         - Score Page 2
-         - Score Page 3
-         - Score Page 4
-         - Score Page 5
+         - Page A1
+         - Page A2
+         - Page B1
+         - Page B2
+         - Page C1
        text:
          - myparent
          - myparent
@@ -32,25 +32,20 @@ pageds:
          - myparent
        page_struct:
          -
-           - "Main"
-           - "Main--Section 1"
-           - "Main--Section 1--Page 1"
+           - "Section A"
+           - "Section A--Page A1"
          -
-           - "Main"
-           - "Main--Section 1"
-           - "Main--Section 1--Page 2"
+           - "Section A"
+           - "Section A--Page A2"
          -
-           - "Main"
-           - "Main--Section 1"
-           - "Main--Section 1--Page 3"
+           - "Section B"
+           - "Section B--Page B1"
          -
-           - "Main"
-           - "Main--Section 2"
-           - "Main--Section 2--Page 4"
+           - "Section B"
+           - "Section B--Page B2"
          -
-           - "Main"
-           - "Main--Section 3"
-           - "Main--Section 3--Page 5"
+           - "Section C"
+           - "Section C--Page C1"
      content:
        pageImage:
          - bhr9405-1-1.jpg

--- a/spec/fixtures/ingest/pmp/package1/manifest.yml
+++ b/spec/fixtures/ingest/pmp/package1/manifest.yml
@@ -9,7 +9,7 @@ pageds:
      type: score
      publisher: Score Central
      publisher_place: Bumblyburg
-     treestruct:
+     paged_struct:
          - "Scores"
          - "Scores--Ultimate Scores"
          - "Scores--Ultimate Scores--Volume 1"

--- a/spec/fixtures/ingest/pmp/package1/manifest.yml
+++ b/spec/fixtures/ingest/pmp/package1/manifest.yml
@@ -16,7 +16,7 @@ pageds:
    content:
      pagedXML: score_xml.xml
    pages:
-     page count: 10
+     page count: 3
      descMetadata:
        logical_num:
          - Score Page 1
@@ -24,11 +24,33 @@ pageds:
          - Score Page 3
          - Score Page 4
          - Score Page 5
-         - Score Page 6
-         - Score Page 7
-         - Score Page 8
-         - Score Page 9
-         - Score Page 10
+       text:
+         - myparent
+         - myparent
+         - myparent
+         - myparent
+         - myparent
+       page_struct:
+         -
+           - "Main"
+           - "Main--Section 1"
+           - "Main--Section 1--Page 1"
+         -
+           - "Main"
+           - "Main--Section 1"
+           - "Main--Section 1--Page 2"
+         -
+           - "Main"
+           - "Main--Section 1"
+           - "Main--Section 1--Page 3"
+         -
+           - "Main"
+           - "Main--Section 2"
+           - "Main--Section 2--Page 4"
+         -
+           - "Main"
+           - "Main--Section 3"
+           - "Main--Section 3--Page 5"
      content:
        pageImage:
          - bhr9405-1-1.jpg
@@ -36,8 +58,3 @@ pageds:
          - bhr9405-1-3.jpg
          - bhr9405-1-4.jpg
          - bhr9405-1-5.jpg
-         - bhr9405-1-6.jpg
-         - bhr9405-1-7.jpg
-         - bhr9405-1-8.jpg
-         - bhr9405-1-9.jpg
-         - bhr9405-1-10.jpg

--- a/spec/fixtures/ingest/pmp/package1/manifest.yml
+++ b/spec/fixtures/ingest/pmp/package1/manifest.yml
@@ -25,11 +25,11 @@ pageds:
          - Page B2
          - Page C1
        text:
-         - myparent
-         - myparent
-         - myparent
-         - myparent
-         - myparent
+         - Some text about Page A1
+         - Some text about Page A2
+         - Some text about Page B1
+         - Some text about Page B2
+         - Some text about Page C1
        page_struct:
          -
            - "Section A"


### PR DESCRIPTION
This pull request adds the ability to populate a field within a Page object that expresses the hierarchy that the page exists within. This field is then used to create a hierarchical facet that can be used to navigate the pages of a particular paged obj.ect.

The sample manifest driven package contains the hierarchical metadata required to see this in action. Simply run 'rake load_paged_fixtures' to load it
