### PR TITLE
Hpt 272 navigate paged struct

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ gem 'omniauth-cas', :git => "https://github.com/cjcolvar/omniauth-cas.git"
 group :development, :test do
   gem "rspec-rails"
   gem "capybara"
+  gem "launchy"
   gem "factory_girl_rails"
   gem "jettywrapper"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,8 @@ GEM
     kaminari (0.16.1)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     libv8 (3.16.14.3)
     logger (1.2.8)
     mail (2.6.1)
@@ -318,6 +320,7 @@ DEPENDENCIES
   jettywrapper
   jquery-rails
   jquery-ui-rails
+  launchy
   omniauth
   omniauth-cas!
   rails (~> 4.1)

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -28,6 +28,20 @@ class CatalogController < ApplicationController
     return[]
   end
 
+  # view individual paged object with navigation of hierarchical facets
+  def view
+    @response, @documents = get_search_results( { q: "item_id_si:#{params[:id].to_s}"}, {})
+    #FIXME; validate results?  Should be 1 Paged, 0 or more Pages
+
+
+    #FIXME: placeholder testing code to view results
+    @pageds = @documents.select { |x| x["active_fedora_model_ssi"] == "Paged" }
+    @pages = @documents.select { |x| x["active_fedora_model_ssi"] == "Page" }
+    raise "No Paged found for id: #{params[:id].to_s}" if @pageds.empty?
+    @document = @pageds.first
+    render :show
+  end
+
   configure_blacklight do |config|
     config.default_solr_params = {
       :qf => 'title_tesim creator_tesim type_tesim text_tesim',

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -30,16 +30,8 @@ class CatalogController < ApplicationController
 
   # view individual paged object with navigation of hierarchical facets
   def view
-    @response, @documents = get_search_results( { q: "item_id_si:#{params[:id].to_s}"}, {})
-    #FIXME; validate results?  Should be 1 Paged, 0 or more Pages
-
-
-    #FIXME: placeholder testing code to view results
-    @pageds = @documents.select { |x| x["active_fedora_model_ssi"] == "Paged" }
-    @pages = @documents.select { |x| x["active_fedora_model_ssi"] == "Page" }
-    raise "No Paged found for id: #{params[:id].to_s}" if @pageds.empty?
-    @document = @pageds.first
-    render :show
+    params[:q] = "item_id_si:#{params[:id].to_s}"
+    @response, @document_list = get_search_results
   end
 
   configure_blacklight do |config|

--- a/app/views/catalog/_document_header.html.erb
+++ b/app/views/catalog/_document_header.html.erb
@@ -7,7 +7,7 @@
              <% counter = document_counter_with_offset(document_counter) %>
              <%= t('blacklight.search.documents.counter', :counter => counter) if counter %>
            </span>
-          <% if document.document_type == "Paged" %>
+          <% if document.respond_to?(:document_type) and document.document_type == "Paged" %>
               <a href='pageds/<%= document.id %>'>
 	        <% if document.has_key?('title_tesim') %>
 		  <%= document['title_tesim'][0] %>
@@ -15,7 +15,7 @@
 		  <%= t 'pmp.document.untitled.title' %>
 		<% end %>
               </a>
-          <% elsif document.document_type == "Page" %>
+          <% elsif document.respond_to?(:document_type) and document.document_type == "Page" %>
               <a href='pages/<%= document.id %>'>
 	        <% if document.has_key?('logical_number_tesim') %>
 		  <%= document['logical_number_tesim'][0] %>

--- a/app/views/catalog/view.html.erb
+++ b/app/views/catalog/view.html.erb
@@ -1,0 +1,36 @@
+<div id="sidebar" class="span3">
+ <%= render 'search_sidebar' %>
+</div>
+
+<div id="content" class="span9">
+
+    <% unless has_search_parameters? %>
+	    <%# if there are no input/search related params, display the "home" partial -%>
+	    <%= render 'home' %>
+    <% else %>
+
+      <h2 class="hide-text top-content-title"><%= t('blacklight.search.search_results_header') %></h2>
+
+      <% @page_title = t('blacklight.search.title', :application_name => application_name) %>
+
+
+      <% Deprecation.silence(Blacklight::LegacyControllerMethods) { extra_head_content << render_opensearch_response_metadata.html_safe } %>
+
+      <%= render 'search_header' %>
+
+      <h2 class="hide-text"><%= t('blacklight.search.search_results') %></h2>
+
+      <%- if @response.empty? %>
+        <%= render "zero_results" %>
+      <%- elsif render_grouped_response? %>
+        <%= render_grouped_document_index %>
+      <%- else %>
+        <%= render_document_index %>
+      <%- end %>
+
+	    <%= render 'results_pagination' %>
+
+
+    <% end %>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ PagedMedia::Application.routes.draw do
     get :page, on: :member
     get :pages, on: :member
     get :bookreader, on: :member
+    get :view, on: :member, controller: "catalog", action: "view"
   end
 
   root :to => "catalog#index"
@@ -13,6 +14,8 @@ PagedMedia::Application.routes.draw do
   HydraHead.add_routes(self)
   #devise_for :users
   devise_for :users, :controllers => { :omniauth_callbacks => "users/omniauth_callbacks" }
+
+  #get 'pageds/view/:id' => 'catalog#view' 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -117,3 +117,50 @@ require 'spec_helper'
       expect(page).to have_table('listPageds')
     end
   end
+
+  describe CatalogController do
+    before(:all) do
+      @newspaper_without_pages = FactoryGirl.create :paged, :newspaper
+      @newspaper_with_pages = FactoryGirl.create :paged, :newspaper, :with_pages
+    end
+
+    describe "GET view" do
+      let(:get_args) { {id: "SET_FOR_CONTEXT" } }
+      let(:get_view) { get :view, **get_args }
+      context "with no pages" do
+        before(:each) do
+          get_args[:id] = @newspaper_without_pages.id
+          get_view
+        end
+        it "returns only paged object in @documents" do
+          expect(assigns(:documents).size).to eq 1
+          expect(assigns(:pageds).size).to eq 1
+          expect(assigns(:pages).size).to eq 0
+        end
+      end
+      context "with 5 pages" do
+        before(:each) do
+          get_args[:id] = @newspaper_with_pages.id
+          get_view
+        end
+        it "returns paged object and pages in @documents" do
+          expect(assigns(:documents).size).to eq 6
+          expect(assigns(:pageds).size).to eq 1
+          expect(assigns(:pages).size).to eq 5
+        end
+      end
+      context "with invalid paged id" do
+        before(:each) do
+          get_args[:id] = "INVALID ID"
+        end
+        it "raises an error" do
+          expect{ get_view }.to raise_error
+        end
+      end
+    end
+
+   after(:all) do
+     @newspaper_without_pages.delete
+     @newspaper_with_pages.delete
+   end
+  end

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -132,10 +132,8 @@ require 'spec_helper'
           get_args[:id] = @newspaper_without_pages.id
           get_view
         end
-        it "returns only paged object in @documents" do
-          expect(assigns(:documents).size).to eq 1
-          expect(assigns(:pageds).size).to eq 1
-          expect(assigns(:pages).size).to eq 0
+        it "returns only paged object in @document_list" do
+          expect(assigns(:document_list).size).to eq 1
         end
       end
       context "with 5 pages" do
@@ -143,24 +141,23 @@ require 'spec_helper'
           get_args[:id] = @newspaper_with_pages.id
           get_view
         end
-        it "returns paged object and pages in @documents" do
-          expect(assigns(:documents).size).to eq 6
-          expect(assigns(:pageds).size).to eq 1
-          expect(assigns(:pages).size).to eq 5
+        it "returns paged object and pages in @document_list" do
+          expect(assigns(:document_list).size).to eq 6
         end
       end
       context "with invalid paged id" do
         before(:each) do
           get_args[:id] = "INVALID ID"
         end
-        it "raises an error" do
-          expect{ get_view }.to raise_error
+        it "returns no objects in @document_list" do
+          expect(assigns(:document_list).to_a.size).to eq 0
         end
       end
     end
 
    after(:all) do
      @newspaper_without_pages.delete
+     @newspaper_with_pages.pages.each { |page| page.delete }
      @newspaper_with_pages.delete
    end
   end

--- a/spec/routing/routes_spec.rb
+++ b/spec/routing/routes_spec.rb
@@ -1,0 +1,7 @@
+require 'spec_helper'
+
+describe "pageds" do
+  specify "view action routes to catalog#view" do
+    expect(get("/pageds/:id/view")).to route_to controller: "catalog", action: "view", id: ":id"
+  end
+end


### PR DESCRIPTION
Updated with HPT-272 subtask work to handle:
- new route for catalog#view
- new catalog#view controller action
- new view template -- just a copy of the default index for catalog search results

Other minor inclusions:
- Added launchy gem to support save_and_open_page action in tests
- Added bug workaround for Blacklight _sometimes_ returning results missing .document_type support
