### PR TITLE
HPT-357 reorder: drop changes to logical_number

### DIFF
--- a/app/controllers/pageds_controller.rb
+++ b/app/controllers/pageds_controller.rb
@@ -69,7 +69,7 @@ class PagedsController < ApplicationController
   # GET /pageds/1/pages.json
   def pages
     page_rsp = {}
-    search = Blacklight.solr.select :params => { :q => params[:id], :fl => "pages_ss" }
+    search = ActiveFedora::SolrService.instance.conn.select :params => { :q => params[:id], :fl => "pages_ss" }
     unless search['response']['numFound'].to_i == 0
       parsed = JSON.parse(search['response']['docs'][0]['pages_ss'])
       if params[:index].nil?
@@ -104,9 +104,6 @@ class PagedsController < ApplicationController
       pages = []
       page_ids.each do |page_id|
         pages << Page.find(page_id)
-      end
-      pages.each_with_index do |page, index|
-        page.logical_number = (index + 1).to_s
       end
 
       previous_page = nil


### PR DESCRIPTION
Deleted lines that were updating logical_number on page reorder.
Also changed Blacklight.solr call to new method, to remove deprecation warning.
