### PR TITLE
Change spec tests to run unchecked saves on Pages when created as children of a test Paged

### DIFF
--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -20,6 +20,7 @@ class Page < ActiveFedora::Base
   has_attributes :text,  datastream: 'descMetadata', multiple: false
   has_attributes :page_struct, datastream: 'descMetadata', multiple: true
 
+  # skip_sibling_validation both skips the custom validation and runs an unchecked save
   attr_accessor :skip_sibling_validation
   validate :validate_has_required_siblings, unless: :skip_sibling_validation
 
@@ -112,7 +113,7 @@ class Page < ActiveFedora::Base
   # method's internal use.
   def save(opts={})
 
-    if (opts.has_key?(:unchecked))
+    if (opts.has_key?(:unchecked) || skip_sibling_validation)
       return super()
     end
 

--- a/app/script/load_package.rb
+++ b/app/script/load_package.rb
@@ -9,7 +9,7 @@ describe 'Loading objects' do
 
   context 'Loading an example score' do
     it 'should create a score and load pages' do
-      @test_paged.pages.each {|page|
+      @test_paged.pages.sort { |a, b| a.logical_number <=> b.logical_number }.each {|page|
         p 'Loaded ' + page.logical_number
       }
     end

--- a/spec/controllers/pageds_controller_spec.rb
+++ b/spec/controllers/pageds_controller_spec.rb
@@ -102,12 +102,14 @@ describe PagedsController do
   end
 
   describe '#pages' do
+    let!(:ordered_pages) { test_paged.pages.sort { |a, b| a.logical_number <=> b.logical_number } }
     it 'should return pid and image ds uri given an index integer' do
-      get :pages, id: test_paged.id, index: 1
+      index = 1
+      get :pages, id: test_paged.id, index: index
       parsed = JSON.parse response.body
-      expect(parsed['id']).to eq test_paged.pages[1].pid
-      expect(parsed['index']).to eq 1.to_s
-      expect(parsed['ds_url']).to match /#{ERB::Util.url_encode(test_paged.pages[1].pid)}\/datastreams\/pageImage\/content$/
+      expect(parsed['id']).to eq ordered_pages[index].pid
+      expect(parsed['index']).to eq index.to_s
+      expect(parsed['ds_url']).to match /#{ERB::Util.url_encode(ordered_pages[index].pid)}\/datastreams\/pageImage\/content$/
     end
   end
 

--- a/spec/factories/page_factories.rb
+++ b/spec/factories/page_factories.rb
@@ -3,6 +3,10 @@ FactoryGirl.define do
   #Create a page object
   factory :page, class: Page do
     logical_number "Page 1"
+
+    trait :unchecked do
+      skip_sibling_validation true
+    end
   end
   
 end

--- a/spec/factories/paged_factories.rb
+++ b/spec/factories/paged_factories.rb
@@ -25,46 +25,39 @@ FactoryGirl.define do
     trait :with_pages do
       after(:create) do |paged|
         pages = Array.new
-        pages[0] = create(:page, paged: paged, logical_number: "Page 1")
-        paged.reload
-        i = 1
-        while i < 5 do
-          pages[i] = create(:page, paged: paged, logical_number: "Page #{i + 1}", prev_page: pages[i - 1].pid)
-          paged.reload
-          i += 1
+        (0...5).each do |i|
+          pages[i] = create(:page, :unchecked, paged: paged, logical_number: "Page #{i + 1}", prev_page: i.zero? ? nil : pages[i - 1].pid)
         end
+	next_page = nil
+	pages.reverse_each do |page|
+	  page.next_page = next_page.pid if next_page
+	  page.skip_sibling_validation = true
+	  page.save!(unchecked: true)
+	  next_page = page
+	end
+	paged.reload
         paged.update_index
       end
     end
     
     # Create paged object with sample score pages
     trait :with_score_pages do
+      with_pages
       after(:create) do |paged|
-        pages = Array.new
-        pages[0] = create(:page, paged: paged, logical_number: "Page 1")
-        paged.reload
-        i = 1
-        while i < 5 do
-          pages[i] = create(:page, paged: paged, logical_number: "Page #{i + 1}", prev_page: pages[i - 1].pid)
-          paged.reload
-          i += 1
+        pages = paged.pages.sort { |a, b| a.logical_number <=> b.logical_number }
+        (0...pages.size).each do |i|
+          score_page = 'spec/fixtures/scores/bhr9405/bhr9405-1-' + (i + 1).to_s + '.jpg'
+          pages[i].pageImage.content = File.open(Rails.root + score_page)
+	  pages[i].skip_sibling_validation = true
+	  pages[i].save!(unchecked: true)
         end
-        pages.each do |page|
-          page.reload
-          p pages.index(page)
-          p page.pid
-          p page.logical_number
-          score_page =  'spec/fixtures/scores/bhr9405/bhr9405-1-' + (pages.index(page)+1).to_s + '.jpg'
-          p score_page
-          page.pageImage.content = File.open(Rails.root + score_page)
-          page.save
-        end
-        paged.update_index
       end
     end
 
+    # Does not use with_pages trait, as logic differs, and may be deprecated
     # Create paged object from ingest package with sample pages
     trait :package_with_pages do
+      package
       after(:create) do |paged|
         # TODO The manifest file is set here but should be discovered by walking tree of package dirs
         manifest_file = "spec/fixtures/ingest/pmp/package1/manifest.yml"
@@ -73,28 +66,22 @@ FactoryGirl.define do
         #   of pageds found in the manifest file
         page_data = file_content["pageds"][0]["pages"]
         pages = Array.new
-        pages[0] = create(:page, paged: paged, logical_number: page_data["descMetadata"]["logical_num"][0], text: page_data["descMetadata"]["text"][0], page_struct: page_data["descMetadata"]["page_struct"][0])
-        paged.reload
-        i = 1
-        while i < page_data["page count"] do
-          pages[i] = create(:page, paged: paged, logical_number: page_data["descMetadata"]["logical_num"][i], prev_page: pages[i - 1].pid, text: page_data["descMetadata"]["text"][i], page_struct: page_data["descMetadata"]["page_struct"][i])
-          paged.reload
-          i += 1
+        (0...page_data["page count"].to_i).each do |i|
+          pages[i] = create(:page, :unchecked, paged: paged, logical_number: page_data["descMetadata"]["logical_number"][i], prev_page: i.zero? ? nil : pages[i - 1].pid, text: page_data["descMetadata"]["text"][i], page_struct: page_data["descMetadata"]["page_struct"][i])
+          package_page =  'spec/fixtures/ingest/pmp/package1/' + 'content/' + page_data["content"]["pageImage"][i]
+          pages[i].pageImage.content = File.open(Rails.root + package_page)
         end
-        pages.each do |page|
-          page.reload
-          p pages.index(page)
-          p page.pid
-          p page.logical_number
-          package_page =  'spec/fixtures/ingest/pmp/package1/' + 'content/' + page_data["content"]["pageImage"][pages.index(page)]
-          p package_page
-          page.pageImage.content = File.open(Rails.root + package_page)
-          page.save
+        next_page = nil
+        pages.reverse_each do |page|
+          page.next_page = next_page.pid if next_page
+          page.skip_sibling_validation = true
+          page.save!(unchecked: true)
+          next_page = page
         end
+	paged.reload
         paged.update_index
       end
     end
-
     
     #Create a newspaper
     trait :newspaper do


### PR DESCRIPTION
Non-test refactoring:
- In the page model, the skip_sibling_validation trait now automatically calls an unchecked save (in addition to skipping validate_has_required_siblings)

Test refactoring:
- Paged factories has with_score_pages as a nested trait of with_pages
- Paged factories do unchecked saves on pages created with with_pages, with_score_pages, with_package_pages traits

In my environment, this cuts test time from about 2m30 to about 2m00.
