### PR TITLE
HPT-363 Performance for accessing objects with lots of pages

### DIFF
--- a/app/controllers/pageds_controller.rb
+++ b/app/controllers/pageds_controller.rb
@@ -1,5 +1,5 @@
 class PagedsController < ApplicationController
-  before_action :set_paged, only: [:show, :edit, :update, :destroy, :bookreader]
+  before_action :set_paged, only: [:show, :edit, :update, :destroy, :bookreader, :validate]
 
   # GET /pageds
   # GET /pageds.json
@@ -11,6 +11,18 @@ class PagedsController < ApplicationController
   # GET /pageds/1.json
   def show
     @ordered = JSON.parse(find_pages())
+  end
+
+  def validate
+    @ordered = JSON.parse(find_pages())
+    validated, @error = @paged.order_pages()
+    if @error
+      flash.now[:error] = "ERROR Ordering Items : #{@error}"
+    end
+    respond_to do |format|
+      format.html { render action: 'show' }
+      format.json { render action: 'show' }
+    end
   end
 
   # GET /pageds/new

--- a/app/controllers/pageds_controller.rb
+++ b/app/controllers/pageds_controller.rb
@@ -10,13 +10,7 @@ class PagedsController < ApplicationController
   # GET /pageds/1
   # GET /pageds/1.json
   def show
-#    @ordered, @error = @paged.order_pages()
     @ordered = JSON.parse(find_pages())
-=begin
-    if @error
-      flash.now[:error] = "ERROR Ordering Items : #{@error}"
-    end
-=end
   end
 
   # GET /pageds/new
@@ -72,23 +66,20 @@ class PagedsController < ApplicationController
   # GET /pageds/1/pages.json
   def pages
     page_rsp = {}
-    search = ActiveFedora::SolrService.instance.conn.select :params => { :q => params[:id], :fl => "pages_ss" }
-    unless search['response']['numFound'].to_i == 0
-      parsed = JSON.parse(search['response']['docs'][0]['pages_ss'])
-      if params[:index].nil?
-        page_rsp = parsed
-      else
-        unless params[:index].to_i > parsed.count
-          page_id = parsed[params[:index].to_i]['id']
-          ds_url = parsed[params[:index].to_i]['ds_url']
-          ds_url ||= ''
-          page_rsp = {:id => page_id, :index => params[:index], :ds_url => ds_url}
-        else
-          page_rsp = {:id => params[:id], :index => params[:index], :error => 'Index out of bounds'}
-        end
-      end
+    search = find_pages
+    parsed = JSON.parse(search)
+    if params[:index].nil?
+      page_rsp = parsed
     else
-      page_rsp = {:id => params[:id], :error => 'No pages'}
+      unless params[:index].to_i > parsed.count
+        page_id = parsed[params[:index].to_i]['id']
+        ds_url = parsed[params[:index].to_i]['ds_url']
+        logical_number = parsed[params[:index].to_i]['logical_number']
+        ds_url ||= ''
+        page_rsp = {:id => page_id, :index => params[:index], :logical_number => logical_number, :ds_url => ds_url}
+      else
+        page_rsp = {:id => params[:id], :index => params[:index], :error => 'Index out of bounds'}
+      end
     end
     respond_to do |format|
       format.html { render json: page_rsp, head: :no_content }

--- a/app/controllers/pageds_controller.rb
+++ b/app/controllers/pageds_controller.rb
@@ -10,10 +10,13 @@ class PagedsController < ApplicationController
   # GET /pageds/1
   # GET /pageds/1.json
   def show
-    @ordered, @error = @paged.order_pages()
+#    @ordered, @error = @paged.order_pages()
+    @ordered = JSON.parse(find_pages())
+=begin
     if @error
       flash.now[:error] = "ERROR Ordering Items : #{@error}"
     end
+=end
   end
 
   # GET /pageds/new
@@ -136,6 +139,19 @@ class PagedsController < ApplicationController
   end
 
   private
+
+  def find_pages
+    pages = {}
+    search = ActiveFedora::SolrService.instance.conn.select :params => { :q => params[:id], :fl => "pages_ss" }
+    unless search['response']['numFound'].to_i == 0
+      pages = search['response']['docs'][0]['pages_ss']
+    else
+      pages = {:id => params[:id], :error => 'No pages'}
+    end
+    return pages
+  end
+
+
     # Use callbacks to share common setup or constraints between actions.
     def set_paged
       @paged = Paged.find(params[:id])

--- a/app/models/paged.rb
+++ b/app/models/paged.rb
@@ -100,7 +100,7 @@ class Paged < ActiveFedora::Base
     pages = []
     fedora_url = ActiveFedora.fedora_config.credentials[:url] + '/'
     self.order_pages[0].each_with_index do |page, index|
-      pages.push({:id => page.pid, :index => index.to_s, :ds_url => fedora_url + page.image_datastream.url})
+      pages.push({:id => page.pid, :index => index.to_s, :logical_number => page.logical_number, :ds_url => fedora_url + page.image_datastream.url})
     end
     pages
   end

--- a/app/views/pageds/_paged_pages.html.erb
+++ b/app/views/pageds/_paged_pages.html.erb
@@ -14,26 +14,18 @@
       <% ordered.each do |page| %>
       <tr>
         <td>
-          <% if page.image_datastream.mimeType %>
             <%= link_to image_tag(
-                    ActiveFedora.fedora_config.credentials[:url] + "/" + page.image_datastream.url,
-                    alt: page.image_datastream.label,
+                    page["ds_url"],
                     height: "64",
                     width: "64"
                   ),
-                  page
+                  page["id"]
             %>
-          <% end %>
         </td>
-        <td class='logical_numbers'><%= page.logical_number %></td>
-        <td><%= page.id %></td>
-        <td><%= page.prev_page %></td>
-        <td><%= page.next_page %></td>
-        <td>
-          <%= link_to 'Show', page %> |
-          <%= link_to 'Edit', edit_page_path(page) %> |
-          <%= link_to 'Destroy', page, method: :delete, data: { confirm: 'Are you sure?' } %>
-        </td>
+        <td class='logical_numbers'><%= page["index"] %></td>
+        <td>page.id</td>
+        <td>page.prev_page</td>
+        <td>page.next_page</td>
       </tr>
       <% end %>
     </table>

--- a/app/views/pageds/_paged_pages.html.erb
+++ b/app/views/pageds/_paged_pages.html.erb
@@ -12,7 +12,11 @@
       <% ordered.each do |page| %>
       <tr>
         <td>
-            <%= link_to "image",
+            <%= link_to image_tag(
+                    page["ds_url"],
+                    height: "64",
+                    width: "64"
+                  ),
                   page_path(page["id"])
             %>
         </td>

--- a/app/views/pageds/_paged_pages.html.erb
+++ b/app/views/pageds/_paged_pages.html.erb
@@ -7,25 +7,23 @@
         <td></td>
         <th>Logical Number</th>
         <th>Page ID</th>
-        <th>Previous Page</th>
-        <th>Next Page</th>
         <th>Links</th>
       </tr>
       <% ordered.each do |page| %>
       <tr>
         <td>
-            <%= link_to image_tag(
-                    page["ds_url"],
-                    height: "64",
-                    width: "64"
-                  ),
-                  page["id"]
+            <%= link_to "image",
+                  page_path(page["id"])
             %>
         </td>
-        <td class='logical_numbers'><%= page["index"] %></td>
-        <td>page.id</td>
-        <td>page.prev_page</td>
-        <td>page.next_page</td>
+        <td class='logical_numbers'><%= page["logical_number"] %></td>
+        <td><%= page["id"] =%></td>
+        <td>
+          <%= link_to 'Show', page_path(page["id"]) %> |
+          <%= link_to 'Edit', edit_page_path(page["id"]) %> |
+          <%= link_to 'Destroy', page_path(page["id"]), method: :delete, data: { confirm: 'Are you sure?' } %>
+        </td>
+
       </tr>
       <% end %>
     </table>

--- a/app/views/pageds/_reorder_pages.html.erb
+++ b/app/views/pageds/_reorder_pages.html.erb
@@ -4,8 +4,8 @@
     <%= form_for(@paged, url: { action: :reorder }) do |f| %>
       <ul id="sortable_pages">
       <% @ordered.each do |page| %>
-        <li id="<%= page.id %>" class="ui-state-default ui-sortable-handle">
-	  <%= page.logical_number %>. <%= page.id %>
+        <li id="<%= page["id"] %>" class="ui-state-default ui-sortable-handle">
+	  <%= page["index"] %>. <%= page["id"] %>
 	</li>
       <% end %>
       </ul>

--- a/app/views/pageds/_reorder_pages.html.erb
+++ b/app/views/pageds/_reorder_pages.html.erb
@@ -5,7 +5,7 @@
       <ul id="sortable_pages">
       <% @ordered.each do |page| %>
         <li id="<%= page["id"] %>" class="ui-state-default ui-sortable-handle">
-	  <%= page["index"] %>. <%= page["id"] %>
+	  <%= page["logical_number"] %>. <%= page["id"] %>
 	</li>
       <% end %>
       </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ PagedMedia::Application.routes.draw do
     get :page, on: :member
     get :pages, on: :member
     get :bookreader, on: :member
+    get :validate, on: :member
     get :view, on: :member, controller: "catalog", action: "view"
   end
 

--- a/spec/features/pageds_spec.rb
+++ b/spec/features/pageds_spec.rb
@@ -24,7 +24,7 @@ describe 'For page listing' do
           page.save!
         end
       }      
-      visit pageds_path + '/' + test_paged.pid
+      visit pageds_path + '/' + test_paged.pid + '/validate'
       # Return page 3's prev page
       page3.prev_page = prev_page
       page3.save!
@@ -45,7 +45,7 @@ describe 'For page listing' do
           page.save!
         end
       }
-      visit pageds_path + '/' + test_paged.pid
+      visit pageds_path + '/' + test_paged.pid + '/validate'
       # Return page 3's prev page
       page3.next_page = next_page
       page3.save!
@@ -66,7 +66,7 @@ describe 'For page listing' do
           page.save!
         end
       }
-      visit pageds_path + '/' + test_paged.pid
+      visit pageds_path + '/' + test_paged.pid + '/validate'
       # Return page 3's prev page
       page3.next_page = next_page
       page3.save!


### PR DESCRIPTION
This is a substantial refactoring of how the Paged controller and views work to display member pages:
- Previous implementation relied on an array of pages created in the 'show' action after running Paged.order_pages, which is very time consuming
- Now the 'show' action passes a hash from a SOLR query, like the 'pages' action for the IA BookReader
- There is now a private find_pages method in the controller for 'show' and 'pages' to get pages from SOLR
- The automatic validation of ordering that used to occur in the 'show' action has been taken out since it _has_ to perform Paged.order_pages
  - Validation of ordering can now be accomplished via a new action and route: pageds/:id/validate
  - the feature tests checking for validation errors were changed to match new validate route
- All view partials were adjusted to account for the controller now passing hash of page values vs. an array of pages
