### PR TITLE
HPT-206 Refactor manifest

### DIFF
--- a/lib/tasks/batch_import.rb
+++ b/lib/tasks/batch_import.rb
@@ -75,7 +75,7 @@ def import_paged(subdir, paged_yaml)
       puts "No pages specified for page object."
     else
       #TODO: check page count exists?
-      page_count = pages_yaml["page count"].to_i
+      page_count = pages_yaml.count
       puts "Processing #{page_count.to_s} pages."
       #TODO: check page count matches pages provided?
       pages = []
@@ -84,8 +84,8 @@ def import_paged(subdir, paged_yaml)
       (0...page_count).each do |index|
         page_attributes = { paged_id: paged.pid, skip_sibling_validation: true }
         page_attributes[:prev_page] = prev_page.pid if prev_page
-        pages_yaml["descMetadata"].each_pair do |key, values|
-          page_attributes[key.to_sym] = values[index]
+        pages_yaml[index]["descMetadata"].each_pair do |key, value|
+          page_attributes[key.to_sym] = value
         end
         begin
 	  page = Page.new(page_attributes)
@@ -94,7 +94,7 @@ def import_paged(subdir, paged_yaml)
           puts page_attributes.inspect
           break
         end
-        pageImage = pages_yaml["content"]["pageImage"][index] if pages_yaml["content"]
+        pageImage = pages_yaml[index]["content"]["pageImage"] if pages_yaml[index]["content"]
 	page.pageImage.content = File.open(Rails.root + subdir + "content/" + pageImage) if pageImage
 	if page.save(unchecked: true)
 	  page.reload

--- a/lib/tasks/batch_import.rb
+++ b/lib/tasks/batch_import.rb
@@ -63,7 +63,7 @@ def import_paged(subdir, paged_yaml)
   if paged
     #TODO: check for failed connection
     if paged.save
-      puts "Paged object successfully created."
+      puts "Paged object #{paged.pid} successfully created."
     else
       puts "ABORTING PAGED CREATION: problem saving paged object"
       puts paged.errors.messages

--- a/spec/factories/paged_factories.rb
+++ b/spec/factories/paged_factories.rb
@@ -66,9 +66,9 @@ FactoryGirl.define do
         #   of pageds found in the manifest file
         page_data = file_content["pageds"][0]["pages"]
         pages = Array.new
-        (0...page_data["page count"].to_i).each do |i|
-          pages[i] = create(:page, :unchecked, paged: paged, logical_number: page_data["descMetadata"]["logical_number"][i], prev_page: i.zero? ? nil : pages[i - 1].pid, text: page_data["descMetadata"]["text"][i], page_struct: page_data["descMetadata"]["page_struct"][i])
-          package_page =  'spec/fixtures/ingest/pmp/package1/' + 'content/' + page_data["content"]["pageImage"][i]
+        (0...page_data.count).each do |i|
+          pages[i] = create(:page, :unchecked, paged: paged, logical_number: page_data[i]["descMetadata"]["logical_number"].to_s, prev_page: i.zero? ? nil : pages[i - 1].pid, text: page_data[i]["descMetadata"]["text"].to_s, page_struct: page_data[i]["descMetadata"]["page_struct"])
+          package_page =  'spec/fixtures/ingest/pmp/package1/' + 'content/' + page_data[i]["content"]["pageImage"]
           pages[i].pageImage.content = File.open(Rails.root + package_page)
         end
         next_page = nil

--- a/spec/fixtures/ingest/pmp/package1/manifest.yml
+++ b/spec/fixtures/ingest/pmp/package1/manifest.yml
@@ -43,3 +43,66 @@ pageds:
            - "Section B--Page B1"
        content:
          pageImage: bhr9405-1-3.jpg
+     -
+       descMetadata:
+         logical_number: Page B2
+         text: Some text about Page B2
+         page_struct:
+           - "Section B"
+           - "Section B--Page B2"
+       content:
+         pageImage: bhr9405-1-4.jpg
+     -
+       descMetadata:
+         logical_number: Page B3
+         text: Some text about Page B3
+         page_struct:
+           - "Section B"
+           - "Section B--Page B3"
+       content:
+         pageImage: bhr9405-1-5.jpg
+     -
+       descMetadata:
+         logical_number: Page C1
+         text: Some text about Page C1
+         page_struct:
+           - "Section C"
+           - "Section C--Page C1"
+       content:
+         pageImage: bhr9405-1-6.jpg
+     -
+       descMetadata:
+         logical_number: Page C2
+         text: Some text about Page C2
+         page_struct:
+           - "Section C"
+           - "Section C--Page C2"
+       content:
+         pageImage: bhr9405-1-7.jpg
+     -
+       descMetadata:
+         logical_number: Page C3
+         text: Some text about Page C3
+         page_struct:
+           - "Section C"
+           - "Section C--Page C3"
+       content:
+         pageImage: bhr9405-1-8.jpg
+     -
+       descMetadata:
+         logical_number: Page C4
+         text: Some text about Page C4
+         page_struct:
+           - "Section C"
+           - "Section C--Page C4"
+       content:
+         pageImage: bhr9405-1-9.jpg
+     -
+       descMetadata:
+         logical_number: Page C5
+         text: Some text about Page C5
+         page_struct:
+           - "Section C"
+           - "Section C--Page C5"
+       content:
+         pageImage: bhr9405-1-10.jpg

--- a/spec/fixtures/ingest/pmp/package1/manifest.yml
+++ b/spec/fixtures/ingest/pmp/package1/manifest.yml
@@ -16,40 +16,30 @@ pageds:
    content:
      pagedXML: score_xml.xml
    pages:
-     page count: 5
-     descMetadata:
-       logical_number:
-         - Page A1
-         - Page A2
-         - Page B1
-         - Page B2
-         - Page C1
-       text:
-         - Some text about Page A1
-         - Some text about Page A2
-         - Some text about Page B1
-         - Some text about Page B2
-         - Some text about Page C1
-       page_struct:
-         -
+     -
+       descMetadata:
+         logical_number: Page A1
+         text: Some text about Page A1
+         page_struct:
            - "Section A"
            - "Section A--Page A1"
-         -
+       content:
+         pageImage: bhr9405-1-1.jpg
+     -
+       descMetadata:
+         logical_number: Page A2
+         text: Some text about Page A2
+         page_struct:
            - "Section A"
            - "Section A--Page A2"
-         -
+       content:
+         pageImage: bhr9405-1-2.jpg
+     -
+       descMetadata:
+         logical_number: Page B1
+         text: Some text about Page B1
+         page_struct:
            - "Section B"
            - "Section B--Page B1"
-         -
-           - "Section B"
-           - "Section B--Page B2"
-         -
-           - "Section C"
-           - "Section C--Page C1"
-     content:
-       pageImage:
-         - bhr9405-1-1.jpg
-         - bhr9405-1-2.jpg
-         - bhr9405-1-3.jpg
-         - bhr9405-1-4.jpg
-         - bhr9405-1-5.jpg
+       content:
+         pageImage: bhr9405-1-3.jpg


### PR DESCRIPTION
This pull request contains a new sample manifest file in the packaged ingest fixture, and changes batch_import.rb and a factorygirl definition to work with the new format. The new manifest format structures the pages section to be nested, where each page's relevant metadata and content are grouped instead of having ordered and separate sections. This should make transformations from sources easier, plus parsing and walking the YAML manifest is cleaner.
