### PR TITLE
[HPT-435] Replaced placeholder for date field in paged form.

### DIFF
--- a/app/views/pageds/_form.html.erb
+++ b/app/views/pageds/_form.html.erb
@@ -36,7 +36,7 @@
     </li>
     <li class="field">
       <%= f.label "Date of Publication" %>
-      <%= f.date_field :issued, placeholder: 'mm/dd/yyyy' %>
+      <%= f.date_field :issued, placeholder: 'yyyy-mm-dd' %>
     </li>
   
     <% if !@paged.new? %>


### PR DESCRIPTION
Quick one Liner: Another story (hpt-307) will validation the date field, but for now this fixes the issue of telling the user the wrong format to enter for the date in when creating a paged object.
