### PR TITLE
HPT-388 HPT-424 descMetadata as modularized RDF

### DIFF
--- a/app/models/datastreams/basic_rdf_properties.rb
+++ b/app/models/datastreams/basic_rdf_properties.rb
@@ -46,7 +46,9 @@ module BasicRdfProperties
       end
       map.source(in: RDF::DC)
       map.coverage(in: RDF::DC)
-      map.type(in: RDF::DC)
+      map.type(in: RDF::DC) do |index|
+        index.as :stored_searchable
+      end
     end
   end
 end

--- a/app/models/datastreams/basic_rdf_properties.rb
+++ b/app/models/datastreams/basic_rdf_properties.rb
@@ -29,7 +29,7 @@ module BasicRdfProperties
       map.created(in: RDF::DC)
       map.issued(in: RDF::DC) do |index|
         index.type :date
-        index.as :stored_sortable
+        index.as :stored_searchable
       end
       map.date(in: RDF::DC) do |index|
         index.type :date

--- a/app/models/datastreams/basic_rdf_properties.rb
+++ b/app/models/datastreams/basic_rdf_properties.rb
@@ -1,0 +1,52 @@
+module BasicRdfProperties
+  extend ActiveSupport::Concern
+  included do
+    map_predicates do |map|
+      map.title(in: RDF::DC) do |index|
+        index.as :stored_searchable, :facetable
+      end
+      map.creator(in: RDF::DC) do |index|
+        index.as :stored_searchable, :facetable
+      end
+      map.contributor(in: RDF::DC) do |index|
+        index.as :stored_searchable, :facetable
+      end
+      map.description(in: RDF::DC) do |index|
+      index.type :text
+        index.as :stored_searchable
+      end
+      map.relation(in: RDF::DC)
+      map.rights(in: RDF::DC) do |index|
+        index.as :stored_searchable
+      end
+      map.publisher(in: RDF::DC) do |index|
+        index.as :stored_searchable, :facetable
+      end
+      map.publisher_place(in: RDF::DC, to: "Location") do |index|
+          index.as :stored_searchable, :facetable
+      end
+
+      map.created(in: RDF::DC)
+      map.issued(in: RDF::DC) do |index|
+        index.type :date
+        index.as :stored_sortable
+      end
+      map.date(in: RDF::DC) do |index|
+        index.type :date
+        index.as :stored_sortable
+      end
+      map.subject(in: RDF::DC) do |index|
+        index.as :stored_searchable, :facetable
+      end
+      map.language(in: RDF::DC) do |index|
+        index.as :stored_searchable, :facetable
+      end
+      map.identifier(in: RDF::DC) do |index|
+        index.as :stored_searchable
+      end
+      map.source(in: RDF::DC)
+      map.coverage(in: RDF::DC)
+      map.type(in: RDF::DC)
+    end
+  end
+end

--- a/app/models/datastreams/paged_desc_metadata.rb
+++ b/app/models/datastreams/paged_desc_metadata.rb
@@ -9,5 +9,9 @@ class PagedDescMetadata < ActiveFedora::NtriplesRDFDatastream
     end
   end
 
+  def prefix(name)
+    return "#{name}".to_sym
+  end
+
 
 end

--- a/app/models/datastreams/paged_desc_metadata.rb
+++ b/app/models/datastreams/paged_desc_metadata.rb
@@ -1,0 +1,13 @@
+class PagedDescMetadata < ActiveFedora::NtriplesRDFDatastream
+
+  include BasicRdfProperties
+
+  # Define custom properties not in basic vocabulary definitions
+  map_predicates do |map|
+    map.paged_struct(in: RDF::DC, to: "isPartOf") do |index|
+      index.as :facetable
+    end
+  end
+
+
+end

--- a/app/models/paged.rb
+++ b/app/models/paged.rb
@@ -9,8 +9,7 @@ class Paged < ActiveFedora::Base
 
   has_file_datastream 'pagedXML'
 
-#  has_metadata 'descMetadata', type: PagedMetadataOaiDc
-  has_metadata "descMetadata", type: PagedDescMetadata
+  has_metadata "descMetadata", type: PagedDescMetadata, label: 'PMP PagedObject descriptive metadata'
 
   # Single-value fields
   has_attributes :title, :contributor, :creator, :coverage, :issued, :date, :description,
@@ -30,6 +29,7 @@ class Paged < ActiveFedora::Base
   has_attributes :type, datastream: 'descMetadata', multiple: false
   has_attributes :paged_struct, datastream: 'descMetadata', multiple: true
 =end
+
   before_save :update_paged_struct
 
   # Setter for the XML datastream

--- a/app/models/paged.rb
+++ b/app/models/paged.rb
@@ -9,6 +9,17 @@ class Paged < ActiveFedora::Base
 
   has_file_datastream 'pagedXML'
 
+#  has_metadata 'descMetadata', type: PagedMetadataOaiDc
+  has_metadata "descMetadata", type: PagedDescMetadata
+
+  # Single-value fields
+  has_attributes :title, :contributor, :creator, :coverage, :issued, :date, :description,
+                 :identifier, :language, :publisher, :publisher_place,
+                 :rights, :source, :subject, :type, datastream: :descMetadata, multiple: false
+  # Multi-value fields
+  has_attributes :paged_struct, datastream: :descMetadata, multiple: true
+
+=begin
   has_metadata 'descMetadata', type: PagedMetadataOaiDc, label: 'PMP PagedObject descriptive metadata'
 
   has_attributes :title, datastream: 'descMetadata', multiple: false  # TODO update DC.title as well?
@@ -18,7 +29,7 @@ class Paged < ActiveFedora::Base
   has_attributes :issued, datastream: 'descMetadata', multiple: false
   has_attributes :type, datastream: 'descMetadata', multiple: false
   has_attributes :paged_struct, datastream: 'descMetadata', multiple: true
-
+=end
   before_save :update_paged_struct
 
   # Setter for the XML datastream

--- a/config/locales/pagedmedia.en.yml
+++ b/config/locales/pagedmedia.en.yml
@@ -1,0 +1,22 @@
+en:
+  pagedmedia:
+    fields:
+      RDF::DC:
+        title: "Title"
+        description: "Description"
+        creator: "Creator"
+        subject: "Subject"
+        contributor: "Contributor"
+        publisher: "Publisher"
+        coverage: "Coverage"
+        source: "Source"
+        based_near: "Location"
+        language: "Language"
+        date_uploaded: "Date Uploaded"
+        date_modified: "Date Modified"
+        date_created: "Date Created"
+        rights: "Rights"
+        human_readable_type: "Resource Type"
+        format: "File Format"
+        identifier: "Identifier"
+

--- a/spec/factories/paged_factories.rb
+++ b/spec/factories/paged_factories.rb
@@ -14,7 +14,8 @@ FactoryGirl.define do
     creator "Factory Girl"
     publisher "Generic Publisher"
     publisher_place "Metropolis"
-    issued Time.now
+    # FIXME Why couldn't we get Time.now through the RDF::DC validations?
+    issued "2015-04-06"
 
     #Create a test paged object
     factory :test_paged do

--- a/spec/models/paged_spec.rb
+++ b/spec/models/paged_spec.rb
@@ -7,7 +7,7 @@ describe Paged do
   it "should have the specified datastreams" do
     # Check for descMetadata datastream
     expect(paged.datastreams.keys).to include("descMetadata")
-    expect(paged.descMetadata).to be_kind_of PagedMetadataOaiDc
+    expect(paged.descMetadata).to be_kind_of PagedDescMetadata
     # Check for rightsMetadata datastream
     expect(paged.datastreams.keys).to include("rightsMetadata")
     expect(paged.rightsMetadata).to be_kind_of Hydra::Datastream::RightsMetadata


### PR DESCRIPTION
These commits change the persistence of descriptive metadata as RDF triples and allows the node type to include a common set of Dublin Core fields and additionally be able to include other vocabularies or define its own.

This model change will break any existing objects stored so it is assumed that object access and saving will only work for new items.
