### PR TITLE
[HPT-451] Specifically, the total duration of full tests

### DIFF
--- a/spec/controllers/pageds_controller_spec.rb
+++ b/spec/controllers/pageds_controller_spec.rb
@@ -267,18 +267,13 @@ describe PagedsController, type: :controller do
     end
 
     context 'with valid reorder values' do
-
       let(:reorder_submission) { ordered_pages.reverse.map { |pid| { "id" => pid } }.to_json }
 
       it 'reorders pages' do
-        #expect(Page).to receive(:find).at_least(:once) {|pid| @test_pages[pid.to_i-1]}
         allow(Paged).to receive(:find).and_return(@test_paged)
 
         expect(@test_paged).to receive("restructure_children").with(JSON.parse(reorder_submission))
         patch :reorder, id: @test_paged.pid, reorder_submission: reorder_submission
-        # Check link order
-#        ['2','3','4','5',nil].each_with_index {|p,i| expect(@test_pages[i].prev_sib).to eq(p)}
-#        [nil,'1','2','3','4'].each_with_index {|p,i| expect(@test_pages[i].next_sib).to eq(p)}
       end
 
       it 'redirects to :edit' do
@@ -291,7 +286,6 @@ describe PagedsController, type: :controller do
   end
 
   describe '#bookreader' do
-    render_views
     it 'assigns @paged' do
       allow(Paged).to receive(:find).and_return(@test_paged)
       get :bookreader, id: @test_paged.id

--- a/spec/controllers/pageds_controller_spec.rb
+++ b/spec/controllers/pageds_controller_spec.rb
@@ -115,16 +115,22 @@ describe PagedsController, type: :controller do
       let(:post_create) { post :create, paged: FactoryGirl.attributes_for(:paged) }
 
       it 'assigns @paged' do
+        expect(Paged).to receive(:new).and_return(@test_paged)
+
         post_create
-        expect(assigns(:paged)).to be_a Paged
-        expect(assigns(:paged)).to be_persisted
+        expect(assigns(:paged)).to be_a MockPaged
       end
 
       it 'saves the new object' do
-        expect{ post_create }.to change(Paged, :count).by(1)
+        expect(Paged).to receive(:new).and_return(MockPaged.new)
+
+        post_create
+        expect(assigns(:paged)).to be_persisted
       end
 
       it 'redirects to the object' do
+        expect(Paged).to receive(:new).and_return(@test_paged)
+
         post_create
         expect(response).to redirect_to assigns(:paged)
       end

--- a/spec/controllers/pageds_controller_spec.rb
+++ b/spec/controllers/pageds_controller_spec.rb
@@ -267,82 +267,25 @@ describe PagedsController, type: :controller do
     end
 
     context 'with valid reorder values' do
-      context 'with pages, only' do
-        let(:reorder_submission) { ordered_pages.reverse.map { |pid| { "id" => pid } }.to_json }
 
-        it 'reorders pages' do
-          expect(@test_paged.order_children[0]).to eq ordered_pages.reverse
-        end
+      let(:reorder_submission) { ordered_pages.reverse.map { |pid| { "id" => pid } }.to_json }
 
-        it 'redirects to :edit' do
-          allow(Paged).to receive(:find).and_return(@test_paged)
+      it 'reorders pages' do
+        #expect(Page).to receive(:find).at_least(:once) {|pid| @test_pages[pid.to_i-1]}
+        allow(Paged).to receive(:find).and_return(@test_paged)
 
-          patch :reorder, id: @test_paged.pid, reorder_submission: reorder_submission
-          expect(response).to redirect_to action: :edit
-        end
+        expect(@test_paged).to receive("restructure_children").with(JSON.parse(reorder_submission))
+        patch :reorder, id: @test_paged.pid, reorder_submission: reorder_submission
+        # Check link order
+#        ['2','3','4','5',nil].each_with_index {|p,i| expect(@test_pages[i].prev_sib).to eq(p)}
+#        [nil,'1','2','3','4'].each_with_index {|p,i| expect(@test_pages[i].next_sib).to eq(p)}
       end
 
-      context 'with sections and pages' do
-        let!(:complex_paged) { FactoryGirl.create(:paged, :unchecked, :with_sections_with_pages) }
-      	let!(:original_order) { complex_paged.order_child_objects[0].map { |section| { "id" => section.pid, "children" => section.order_children[0].map { |pid| { "id" => pid } } } } }
-        let(:test_pid) { complex_paged.pid }
+      it 'redirects to :edit' do
+        allow(Paged).to receive(:find).and_return(@test_paged)
 
-        context 'reordering sections' do
-      	  let(:reorder_submission) { original_order.reverse.to_json }
-	        it 'reorders sections' do
-            complex_paged.reload
-	          expect(complex_paged.order_children[0]).to eq original_order.map { |h| h["id"] }.reverse
-      	  end
-      	end
-
-        context 'reparenting sections' do
-          let(:reorder_submission) do
-            [{ "id" => original_order[0]["id"], "children" => original_order[0]["children"] + [original_order[1]]},
-             { "id" => original_order[2]["id"], "children" => original_order[2]["children"]}].to_json
-          end
-
-          it 'reparents section' do
-            complex_paged.reload
-            expect(complex_paged.order_child_objects[0].first.order_children[0].last).to eq original_order[1]["id"]
-          end
-        end
-
-        context 'reordering pages' do
-          let(:reorder_submission) { ordered_pages.reverse.join(',') }
-
-          it 'reorders pages' do
-            expect(Page).to receive(:find).at_least(:once) {|pid| @test_pages[pid.to_i-1]}
-            allow(Paged).to receive(:find).and_return(@test_paged)
-
-            patch :reorder, id: 0, reorder_submission: reorder_submission
-            # Check link order
-            ['2','3','4','5',nil].each_with_index {|p,i| expect(@test_pages[i].prev_sib).to eq(p)}
-            [nil,'1','2','3','4'].each_with_index {|p,i| expect(@test_pages[i].next_sib).to eq(p)}
-          end
-        end
-      end
-
-      context 'reparenting pages' do
-        let(:reorder_array) do
-          [{ "id" => original_order[0]["id"], "children" => original_order[0]["children"] - [original_order[0]["children"].last]},
-           { "id" => original_order[0]["children"].last["id"]},
-           { "id" => original_order[1]["id"], "children" => original_order[1]["children"]},
-           { "id" => original_order[2]["id"], "children" => original_order[2]["children"]}]
-        end
-        let(:reorder_submission) { reorder_array.to_json }
-
-        it 'reparents page' do
-          complex_paged.reload
-          expect(complex_paged.order_children[0]).to eq reorder_array.map { |h| h["id"] }
-        end
-
-        it 'redirects to :edit' do
-          expect(Page).to receive(:find).at_least(:once) {|pid| @test_pages[pid.to_i-1]}
-          expect(Paged).to receive(:find).and_return(@test_paged)
-  
-          patch :reorder, id: @test_paged.pid, reorder_submission: reorder_submission
-          expect(response).to redirect_to action: :edit
-        end
+        patch :reorder, id: @test_paged.pid, reorder_submission: reorder_submission
+        expect(response).to redirect_to action: :edit
       end
     end
   end

--- a/spec/helpers/mock_page.rb
+++ b/spec/helpers/mock_page.rb
@@ -37,6 +37,8 @@ module ModelMocks
   
     def next_sib=(n); @next_sib = n; end
 
+    def update(*); true; end
+
     def valid?; true; end
 
     def save(*); true; end

--- a/spec/helpers/mock_page.rb
+++ b/spec/helpers/mock_page.rb
@@ -1,0 +1,45 @@
+# RSpec::Mocks just doesn't do what I need, so do it the jmockit way (sort of).
+# Copyright 2015 Indiana University
+
+module ModelMocks
+
+  class MockPage
+
+    # Unique identifiers for each new instance.
+    @@next_id = 0
+
+    # Stores each new instance for find() to find
+    @@instances = {}
+
+    def initialize
+      @my_id = 'MockPage:' + (@@next_id.to_s)
+      @@next_id += 1
+
+      @@instances[@my_id] = self
+
+      @prev_sib = nil
+      @next_sib = nil
+    end
+
+    def skip_sibling_validation=(s); end
+
+    def pid; id; end
+  
+    def id; @my_id; end
+  
+    def id=(new_id); @my_id = new_id; end
+  
+    def prev_sib; @prev_sib; end
+  
+    def prev_sib=(p); @prev_sib = p; end
+  
+    def next_sib; @next_sib; end
+  
+    def next_sib=(n); @next_sib = n; end
+
+    def valid?; true; end
+
+    def save(*); true; end
+  end
+
+end

--- a/spec/helpers/mock_paged.rb
+++ b/spec/helpers/mock_paged.rb
@@ -29,9 +29,13 @@ module ModelMocks
 
     # Class methods
 
+    def MockPaged.all; @@instances.values; end
+
+    def MockPaged.count; @@instances.length; end
+
     def MockPaged.find(id); @@instances[id]; end
 
-    def MockPaged.all; @@instances.values; end
+    def MockPaged.model_name; ActiveModel::Name.new(ModelMocks::MockPaged, nil, 'Paged'); end
 
     # Instance methods
 
@@ -59,17 +63,19 @@ module ModelMocks
 
     def skip_sibling_validation=; end
 
-    # ActiveRecord methods
+    # ActiveRecord instance methods
 
-    def count; @@instances.length; end
-
-    def valid?; true; end
+    def destroy; @@instances.delete(@my_id); end
 
     def new_record?; !@persisted; end
 
     def persisted?; @persisted; end
 
     def save(*); @persisted = true; true; end
+
+    def update(*); true; end
+
+    def valid?; true; end
 
   end
 

--- a/spec/helpers/mock_paged.rb
+++ b/spec/helpers/mock_paged.rb
@@ -59,6 +59,8 @@ module ModelMocks
 
     def next_sib=(n); @next_sib = n; end
 
+    def restructure_children(struct); end
+
     def update_index; end
 
     def skip_sibling_validation=; end

--- a/spec/helpers/mock_paged.rb
+++ b/spec/helpers/mock_paged.rb
@@ -1,0 +1,76 @@
+# RSpec::Mocks just doesn't do what I need, so do it the jmockit way (sort of).
+# Copyright 2015 Indiana University
+
+module ModelMocks
+
+  class MockPaged
+
+    # Unique identifiers for each new instance.
+    @@next_id = 0
+
+    # Stores each new instance for find() to find
+    @@instances = {}
+
+    # Constructor
+
+    def initialize
+      @my_id = 'MockPaged:' + (@@next_id.to_s)
+      @@next_id += 1
+
+      @@instances[@my_id] = self
+
+      @prev_sib = nil
+      @next_sib = nil
+      @children = []
+
+      @title = @my_id
+      @persisted = false
+    end
+
+    # Class methods
+
+    def MockPaged.find(id); @@instances[id]; end
+
+    def MockPaged.all; @@instances.values; end
+
+    # Instance methods
+
+    def children; @children; end
+
+    def title; @title; end
+
+    def title=(t); @title = t; end
+
+    def pid; id; end
+
+    def id; @my_id; end
+
+    def id=(new_id); @my_id = new_id; end
+
+    def prev_sib; @prev_sib; end
+
+    def prev_sib=(p); @prev_sib = p; end
+
+    def next_sib; @next_sib; end
+
+    def next_sib=(n); @next_sib = n; end
+
+    def update_index; end
+
+    def skip_sibling_validation=; end
+
+    # ActiveRecord methods
+
+    def count; @@instances.length; end
+
+    def valid?; true; end
+
+    def new_record?; !@persisted; end
+
+    def persisted?; @persisted; end
+
+    def save(*); @persisted = true; true; end
+
+  end
+
+end

--- a/spec/helpers/mock_solr_service.rb
+++ b/spec/helpers/mock_solr_service.rb
@@ -36,9 +36,16 @@ module ServiceMocks
       end
 
       def select(**args)
-        selected = {'response' => {'num_found' => nil, 'docs' => [ {'pages_ss' => nil} ] } }
-        selected['response']['num_found'] = -1 # TODO Count them
-        selected['response']['docs'][0]['pages_ss'] = @index_content
+        selected = {
+          'response' => {
+            'numFound' => @index_content.length,
+            'docs' => [
+              {
+                'pages_ss' => @index_content.to_json
+              }
+            ]
+          }
+        }
         return selected
       end
 

--- a/spec/helpers/mock_solr_service.rb
+++ b/spec/helpers/mock_solr_service.rb
@@ -1,0 +1,54 @@
+# Copyright 2015 Indiana University.
+
+module ServiceMocks
+
+  ## Pretend to be a Solr service connection holder
+  class MockSolrService
+    include Singleton
+
+    def initialize
+      @connection = Connection.new
+    end
+
+    # instance() is provided by Singleton
+    
+    def conn
+      # return something that responds to 'select'
+      @connection
+    end
+
+    ## Set "index content" to be returned by conn.select
+    def index=(content)
+      @connection.index = content
+    end
+
+    private
+
+    ## Pretend to be a connection to a Solr service
+    class Connection
+
+      def commit
+        # do nothing
+      end
+
+      def delete_by_query(query)
+        # do nothing
+      end
+
+      def select(**args)
+        selected = {'response' => {'num_found' => nil, 'docs' => [ {'pages_ss' => nil} ] } }
+        selected['response']['num_found'] = -1 # TODO Count them
+        selected['response']['docs'][0]['pages_ss'] = @index_content
+        return selected
+      end
+
+      ## Set "index content" to be returned by select
+      def index=(content)
+        @index_content = content
+      end
+      
+    end
+
+  end
+
+end


### PR DESCRIPTION
Make the tests themselves run faster.  Controller tests were very slow, because they were calling out to external services (where we still have other performance issues).  This PR makes a start on turning those tests into true unit tests, by mocking Fedora and Solr away.
