### PR TITLE
HPT-464 & HPT-384 Add select options to paged create/edit form type field.

### DIFF
--- a/app/views/pageds/_form.html.erb
+++ b/app/views/pageds/_form.html.erb
@@ -11,15 +11,18 @@
     </div>
   <% end %>
   
+  
   <ol>
     <li>
       <%= f.label :type %>
       <%= f.select(:type) do %>
-        <option value='' disabled selected>Select type</option>
+        <% if !@paged.type %>
+          <option value='' disabled selected>Select type</option>
+        <% end %>
         <% if i18n_set? 'pagedmedia' %>
           <% I18n.t('pagedmedia').each do |ctype, cinfo| %>
-            <% if @paged.type.has_content? %>
-              
+            <% if @paged.type && @paged.type.to_s == ctype.to_s %>
+              <%= content_tag(:option, cinfo[:label] , value: ctype, selected: 'selected') %>
             <% else %>
               <%= content_tag(:option, cinfo[:label] , value: ctype) %>
             <% end %>

--- a/app/views/pageds/_form.html.erb
+++ b/app/views/pageds/_form.html.erb
@@ -10,12 +10,22 @@
       </ul>
     </div>
   <% end %>
-
+  
   <ol>
     <li>
       <%= f.label :type %>
-      <%# f.text_field :type %>
-      <%= f.select(:type, ["Newspaper", "Musical Score", "Book"], prompt: 'Select type') %>
+      <%= f.select(:type) do %>
+        <option value='' disabled selected>Select type</option>
+        <% if i18n_set? 'pagedmedia' %>
+          <% I18n.t('pagedmedia').each do |ctype, cinfo| %>
+            <% if @paged.type.has_content? %>
+              
+            <% else %>
+              <%= content_tag(:option, cinfo[:label] , value: ctype) %>
+            <% end %>
+          <%end %>
+        <% end %>
+      <% end %>
     </li>
     <li>
       <%= f.label :title %>

--- a/config/locales/pagedmedia.en.yml
+++ b/config/locales/pagedmedia.en.yml
@@ -1,11 +1,7 @@
 en:
   pagedmedia:
-    default:
-      fields:
-        RDF::DC:
-          title: "Default Title"
-          description: "Default Description"
     newspaper:
+      label: "Newspaper"
       fields:
         RDF::DC:
           title: "Newspaper Title"
@@ -26,6 +22,7 @@ en:
           format: "File Format"
           identifier: "Identifier"
     score:
+      label: "Musical Score"
       fields:
         RDF::DC:
           title: "Score Title"
@@ -45,5 +42,11 @@ en:
           human_readable_type: "Resource Type"
           format: "File Format"
           identifier: "Identifier"
+    default:
+      label: "Generic Media"
+      fields:
+        RDF::DC:
+          title: "Default Title"
+          description: "Default Description"
 
 

--- a/spec/fixtures/ingest/pmp/.gitignore
+++ b/spec/fixtures/ingest/pmp/.gitignore
@@ -1,0 +1,3 @@
+*
+
+!.gitignore

--- a/spec/fixtures/ingest/pmp/.gitignore
+++ b/spec/fixtures/ingest/pmp/.gitignore
@@ -1,3 +1,3 @@
 *
-
+!/package1
 !.gitignore


### PR DESCRIPTION
This pull populates the paged type field using types available in the locale file (pagedmedia). It also adds a label field to the locale file for this and other future uses.

Also added a .gitignore to spec/fixtures/ingest/pmp so packages can be added without worry about bloating the repo (again.)
