### PR TITLE
HPT-471 Moving reorder functionality to edit view

### DIFF
--- a/app/controllers/pageds_controller.rb
+++ b/app/controllers/pageds_controller.rb
@@ -35,6 +35,7 @@ class PagedsController < ApplicationController
 
   # GET /pageds/1/edit
   def edit
+    @ordered = JSON.parse(find_pages())
     add_breadcrumb @paged.title, @paged
     add_breadcrumb "Edit"
   end
@@ -117,7 +118,7 @@ class PagedsController < ApplicationController
     else
       flash[:notice] = "No changes to the page order were submitted."
     end
-    redirect_to action: :show
+    redirect_to action: :edit
   end
 
   private

--- a/app/views/pageds/edit.html.erb
+++ b/app/views/pageds/edit.html.erb
@@ -7,6 +7,7 @@
   <h1>Paged Media: Edit</h1>
   
   <%= render 'form' %>
+  <%= render partial: 'reorder_pages', locals: { paged: @paged, ordered: @ordered } %>
   
   <%= link_to 'Show', @paged %> |
   <%= link_to 'Back', pageds_path %>

--- a/app/views/pageds/show.html.erb
+++ b/app/views/pageds/show.html.erb
@@ -57,6 +57,6 @@
     <%= render :partial=>'paged_pages', :locals => { :paged => @paged, :ordered => @ordered } %>
   </div>
   
-  <%= render partial: 'reorder_pages', locals: { paged: @paged, ordered: @ordered } %>
+  
 
 </div>

--- a/spec/controllers/pageds_controller_spec.rb
+++ b/spec/controllers/pageds_controller_spec.rb
@@ -152,8 +152,8 @@ describe PagedsController do
       it 'flashes "No change"' do
         expect(flash[:notice]).to match(/No change/i)
       end
-      it 'redirects to :show' do
-        expect(response).to redirect_to action: :show
+      it 'redirects to :edit' do
+        expect(response).to redirect_to action: :edit
       end
     end
     context 'with valid reorder values' do
@@ -164,8 +164,8 @@ describe PagedsController do
           test_paged.reload
           expect(test_paged.order_children[0]).to eq ordered_pages.reverse
         end
-        it 'redirects to :show' do
-          expect(response).to redirect_to action: :show
+        it 'redirects to :edit' do
+          expect(response).to redirect_to action: :edit
         end
       end
       context 'with sections and pages' do


### PR DESCRIPTION
The structure required from ActiveFedora for reordering pages is currently very expensive and is causing the initial paged view to be unnecessarily slow. This shouldn't be in show anyway so moving to edit for now to satisfy HPT-471, but HPT-453 in the backlog will address how it should ideally work.
